### PR TITLE
docs: protect users during Store 0.2.2 review

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,10 +34,10 @@
     "alternateName": "Hermes Connector",
     "url": "https://corsenai.github.io/hermes-connector/",
     "installUrl": "https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm",
-    "downloadUrl": "https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip",
+    "downloadUrl": "https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip",
     "applicationCategory": "BrowserApplication",
     "operatingSystem": "Google Chrome 120+ on Windows, macOS, and Linux",
-    "softwareVersion": "0.2.1",
+    "softwareVersion": "0.2.0",
     "description": "An unofficial Chrome browser extension that connects exact local Hermes Agent sessions to user-selected tabs in a real signed-in Chrome profile.",
     "image": "https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/store-icon-128.png",
     "softwareRequirements": "Google Chrome 120 or later, a local Hermes installation, and the Hermes Connector companion",
@@ -126,6 +126,17 @@
     .button.primary { border-color: transparent; background: linear-gradient(100deg, #287eff, #a94cea 72%, #e647bd); box-shadow: 0 13px 36px rgba(94, 85, 246, .30); }
     .button.primary:hover { box-shadow: 0 17px 44px rgba(115, 74, 240, .42); }
     .microcopy { margin-top: 13px; color: var(--muted); font-size: 13px; }
+
+    .card.transition { margin-top: 34px; padding: 27px; border-color: #8d6a2f; background: radial-gradient(500px 230px at 0% 0%, rgba(246, 176, 49, .12), transparent 70%), linear-gradient(155deg, rgba(31, 27, 26, .98), rgba(10, 15, 28, .98)); }
+    .transition h2 { font-size: clamp(25px, 3vw, 34px); }
+    .transition > p { margin: 11px 0; }
+    .transition .warning { color: #ffe0a0; }
+    .compatibility-scroll { overflow-x: auto; margin: 18px 0; }
+    .compatibility { width: 100%; min-width: 760px; border-collapse: collapse; }
+    .compatibility th, .compatibility td { padding: 14px 15px; border: 1px solid #34415c; text-align: left; vertical-align: top; }
+    .compatibility th { background: #18223b; color: #fff; }
+    .compatibility td { color: #d3ddef; }
+    .compatibility td strong { color: #fff; }
 
     .hero-visual { position: relative; }
     .hero-visual::before { content: ""; position: absolute; inset: 8% -9% -8% 15%; z-index: -1; border-radius: 50%; background: radial-gradient(circle, rgba(74, 122, 255, .28), rgba(218, 51, 213, .10) 42%, transparent 70%); filter: blur(18px); }
@@ -247,15 +258,29 @@
           <p class="lead">Hermes Connector links exact local Hermes Agent sessions to only the Chrome tabs you attach—inside the signed-in browser profile you already use.</p>
           <div class="actions">
             <a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add to Chrome</a>
-            <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip">Download companion 0.2.1</a>
+            <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip">Download companion 0.2.0</a>
           </div>
-          <p class="microcopy">Local companion required · Chrome 120+ · Windows, macOS, and Linux</p>
+          <p class="microcopy">Public Store version: 0.2.0 · Install the companion with the exact same version</p>
         </div>
 
         <figure class="product-frame hero-visual">
           <img src="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/screenshot-product-1280x800.png" width="1280" height="800" alt="Hermes Connector side panel attached to the Project Atlas tab in Chrome" fetchpriority="high">
           <figcaption>Hermes Connector routes the selected Hermes session to its explicitly attached tab.</figcaption>
         </figure>
+      </div>
+
+      <div class="wrap card transition" role="note" aria-labelledby="version-match-title">
+        <p class="kicker">Store update in review</p>
+        <h2 id="version-match-title">Match the companion to the extension version shown by Chrome.</h2>
+        <p>Open <code>chrome://extensions</code> and check Hermes Connector before downloading the local companion.</p>
+        <div class="compatibility-scroll"><table class="compatibility">
+          <thead><tr><th>Extension installed in Chrome</th><th>Compatible local companion</th><th>Use this pair when</th></tr></thead>
+          <tbody>
+            <tr><td><strong>0.2.0</strong> from the <a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">public Chrome Web Store listing</a></td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip">Download companion 0.2.0</a></td><td>Chrome currently shows extension version 0.2.0.</td></tr>
+            <tr><td><strong>0.2.2</strong> Store candidate/reviewer build</td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a></td><td>Google review or Chrome already shows extension version 0.2.2.</td></tr>
+          </tbody>
+        </table></div>
+        <p class="warning"><strong>Do not mix versions:</strong> 0.2.0 works with 0.2.0; 0.2.2 works with 0.2.2. Do not install companion 0.2.2 until Chrome itself shows extension 0.2.2. See the <a href="support/#compatible-versions">versioned setup guide</a>.</p>
       </div>
 
       <div class="wrap trust-strip" role="list" aria-label="Product summary">
@@ -282,7 +307,7 @@
           <article class="card step" style="--glow:rgba(100,107,255,.20)">
             <div class="step-number">2</div>
             <h3>Install the local companion</h3>
-            <p>Download the companion, run the installer once, and restart any running Hermes dashboard, gateway, or chat process.</p>
+            <p>Check the extension version, download the exact matching companion from the table above, run its installer once, and restart Hermes.</p>
           </article>
           <article class="card step" style="--glow:rgba(234,70,199,.18)">
             <div class="step-number">3</div>
@@ -355,8 +380,8 @@
         <div class="card requirements">
           <div class="requirements-row"><strong>Browser</strong><span>Google Chrome 120 or later.</span></div>
           <div class="requirements-row"><strong>Hermes</strong><span>A working local Hermes installation on the same computer.</span></div>
-          <div class="requirements-row"><strong>Companion</strong><span>The Hermes Connector companion, installed once for existing profiles and again after creating a new named Hermes profile.</span></div>
-          <div class="requirements-row"><strong>Operating system</strong><span>Windows, macOS, or Linux. Windows includes a double-click installer; macOS and Linux use <code>./install.sh</code>.</span></div>
+          <div class="requirements-row"><strong>Companion</strong><span>The Hermes Connector companion with exactly the same version as the extension, installed once for existing profiles and again after creating a new named Hermes profile.</span></div>
+          <div class="requirements-row"><strong>Operating system</strong><span>Windows, macOS, or Linux. Windows uses <code>.\install.ps1</code>; companion 0.2.2 also includes a double-click launcher. macOS and Linux use <code>./install.sh</code>.</span></div>
         </div>
       </div>
     </section>
@@ -387,7 +412,7 @@
           </details>
           <details>
             <summary>Does Chrome update Hermes Connector automatically?</summary>
-            <p>Chrome updates the Web Store extension automatically. It cannot update the separately installed local companion, so companion upgrades must be installed manually.</p>
+            <p>Chrome updates the Web Store extension automatically after Google publishes an approved update. It cannot update the separately installed local companion. When Chrome changes the extension from 0.2.0 to 0.2.2, manually install companion 0.2.2 and restart Hermes; never upgrade the companion before the extension.</p>
           </details>
           <details>
             <summary>Is this an official Nous Research extension?</summary>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://corsenai.github.io/hermes-connector/</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-03</lastmod>
   </url>
   <url>
     <loc>https://corsenai.github.io/hermes-connector/support/</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-03</lastmod>
   </url>
   <url>
     <loc>https://corsenai.github.io/hermes-connector/privacy/</loc>

--- a/docs/support/index.html
+++ b/docs/support/index.html
@@ -18,22 +18,37 @@
 <meta name="twitter:image" content="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/promo-marquee-1400x560.png">
 <title>Setup &amp; Support — Hermes Connector for Hermes Agent</title>
 <style>
-  :root{--bg:#090d19;--card:#11182b;--bd:#29375f;--tx:#edf2ff;--mut:#aeb9d2;--acc:#79cfff}*{box-sizing:border-box}body{margin:0;background:radial-gradient(900px 500px at 80% -10%,#281442 0%,var(--bg) 62%);color:var(--tx);font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:52px 20px}main{max-width:800px;margin:auto}h1{font-size:38px;margin:0 0 8px}.sub{color:var(--mut);margin:0 0 28px}.card{background:var(--card);border:1px solid var(--bd);border-radius:16px;padding:25px 29px;margin:0 0 17px}h2{font-size:20px;margin:0 0 10px}li,p{color:#d9e1f2}code{background:#192341;border:1px solid var(--bd);border-radius:6px;padding:2px 6px}a{color:var(--acc)}nav{margin-top:24px;color:var(--mut)}
+  :root{--bg:#090d19;--card:#11182b;--bd:#29375f;--tx:#edf2ff;--mut:#aeb9d2;--acc:#79cfff;--warn:#ffd782}*{box-sizing:border-box}body{margin:0;background:radial-gradient(900px 500px at 80% -10%,#281442 0%,var(--bg) 62%);color:var(--tx);font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:52px 20px}main{max-width:900px;margin:auto}h1{font-size:38px;margin:0 0 8px}.sub{color:var(--mut);margin:0 0 28px}.card{background:var(--card);border:1px solid var(--bd);border-radius:16px;padding:25px 29px;margin:0 0 17px}.transition{border-color:#8e6a2b;background:linear-gradient(145deg,#221b16,var(--card) 62%)}h2{font-size:20px;margin:0 0 10px}h3{font-size:17px;margin:22px 0 8px}li,p{color:#d9e1f2}code{background:#192341;border:1px solid var(--bd);border-radius:6px;padding:2px 6px}a{color:var(--acc)}nav{margin-top:24px;color:var(--mut)}.warning{color:var(--warn)}.table-wrap{overflow-x:auto;margin:18px 0}table{width:100%;min-width:690px;border-collapse:collapse}th,td{padding:13px 14px;border:1px solid var(--bd);text-align:left;vertical-align:top}th{background:#18223b;color:#fff}td{color:#d9e1f2}td strong{color:#fff}.pair{white-space:nowrap}@media(max-width:600px){body{padding:34px 14px}.card{padding:21px 19px}h1{font-size:32px}}
 </style>
 </head>
 <body><main>
   <h1>Hermes Connector support</h1>
-  <p class="sub">Release documentation: 0.2.1 · protocol 4</p>
-  <div class="card"><h2>Install</h2><ol>
-    <li><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip">Download the 0.2.1 companion</a> and extract it.</li>
-    <li>On Windows, double-click <code>Install Hermes Connector.cmd</code> (or run <code>.\install.ps1</code> in PowerShell). On macOS/Linux, run <code>./install.sh</code>.</li>
+  <p class="sub">Chrome Web Store transition: public 0.2.0 · candidate/reviewer 0.2.2</p>
+  <div class="card transition" id="compatible-versions"><h2>Choose the matching extension and companion</h2>
+    <p><strong>Check the extension version first:</strong> open <code>chrome://extensions</code>, find Hermes Connector, and read its version. Install only the companion from the same row.</p>
+    <div class="table-wrap"><table>
+      <thead><tr><th>Extension installed in Chrome</th><th>Compatible local companion</th><th>Who should use it now</th></tr></thead>
+      <tbody>
+        <tr><td><span class="pair"><strong>0.2.0</strong> · <a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">public Chrome Web Store listing</a></span></td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip">Download companion 0.2.0</a><br><small><a href="https://github.com/CorsenAI/hermes-connector/releases/tag/v0.2.0">Open the 0.2.0 release page</a></small></td><td>Everyone whose Chrome extension page currently shows 0.2.0.</td></tr>
+        <tr><td><span class="pair"><strong>0.2.2</strong> · Store candidate/reviewer build</span></td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a><br><small><a href="https://github.com/CorsenAI/hermes-connector/releases/tag/v0.2.2">Open the 0.2.2 release page</a></small></td><td>Google reviewers and users whose Chrome extension page already shows 0.2.2.</td></tr>
+      </tbody>
+    </table></div>
+    <p class="warning"><strong>Do not mix versions.</strong> Extension 0.2.0 must use companion 0.2.0. Extension 0.2.2 must use companion 0.2.2. Companion 0.2.1 is not part of either Store transition pair.</p>
+  </div>
+  <div class="card"><h2>Install the matching companion</h2><ol>
+    <li>Use the compatibility table above to download the companion that exactly matches the version shown by Chrome, then extract it.</li>
+    <li>On Windows with companion 0.2.0, open PowerShell in the extracted folder and run <code>.\install.ps1</code>. Companion 0.2.2 also lets you double-click <code>Install Hermes Connector.cmd</code>. On macOS/Linux, run <code>./install.sh</code>.</li>
     <li>Restart any running Hermes dashboard, gateway, or chat process. Re-run the installer after creating a new named Hermes profile.</li>
     <li>Open the Chrome side panel, paste the private pairing code printed locally, select a Hermes session, and attach only the tabs it may control.</li>
   </ol></div>
-  <div class="card"><h2>Upgrading from an older version</h2><p>Chrome updates the extension automatically, but it cannot update the local companion. Download and run the 0.2.1 companion installer again, then restart every running Hermes dashboard, gateway, and chat process. Your pairing code stays the same. For normal/default installations, the extension safely migrates the old local port 8765 to the isolated 0.2.1 port 8766 once; no manual port change is needed.</p><p><strong>Custom bridge ports only:</strong> custom values are preserved, but a detached 0.2.0 broker may continue owning that same custom port after Hermes closes. After installing 0.2.1, reboot the computer once (or safely stop only the known legacy broker process), then start Hermes again. A normal/default installation does not need this extra reboot.</p><p>Version 0.2.1 stops the repeated local-storage writes found in 0.2.0, but Chrome may not reclaim an already enlarged LevelDB journal immediately. First close every Chrome window completely and reopen Chrome. If disk usage remains abnormally high, removing and reinstalling Hermes Connector safely clears only this extension’s local settings; you will need to paste the pairing code and attach your sessions/tabs again. Do not manually delete arbitrary Chrome profile files.</p></div>
+  <div class="card"><h2>During the 0.2.2 Store review</h2><p>Chrome updates the Web Store extension automatically after Google publishes an approved update, but Chrome cannot update the separately installed local companion.</p><ul>
+    <li><strong>If Chrome still shows 0.2.0:</strong> keep or reinstall companion 0.2.0. Do not install companion 0.2.2 early.</li>
+    <li><strong>When Chrome shows 0.2.2:</strong> install companion 0.2.2, then restart every running Hermes dashboard, gateway, and chat process.</li>
+    <li><strong>If the wrong companion was installed:</strong> run the installer from the correct row above and restart Hermes. Recheck both version numbers before troubleshooting anything else.</li>
+  </ul><p>The default local broker is <code>127.0.0.1:8765</code> for pair 0.2.0 and <code>127.0.0.1:8766</code> for pair 0.2.2.</p></div>
   <div class="card"><h2>Troubleshooting</h2><ul>
-    <li><strong>Companion offline:</strong> confirm Hermes restarted after installation and port <code>127.0.0.1:8766</code> is available.</li>
-    <li><strong>Pairing rejected:</strong> open companion settings and generate/show the current local code, then save it again in the extension.</li>
+    <li><strong>Companion offline:</strong> first confirm that the extension and companion versions match. Then confirm Hermes restarted and the matching default port is available: <code>8765</code> for 0.2.0 or <code>8766</code> for 0.2.2.</li>
+    <li><strong>Pairing rejected:</strong> rerun the matching companion installer to display the local pairing code, then save that code again in the extension.</li>
     <li><strong>Action refused:</strong> select the exact Hermes session and attach a permitted web tab. Restricted Chrome pages cannot be controlled.</li>
     <li><strong>Debugging banner:</strong> disable Trusted input unless native input or dialog handling is needed.</li>
   </ul></div>


### PR DESCRIPTION
## Why
The Chrome Web Store still serves extension 0.2.0 while candidate 0.2.2 is under review. The companion must exactly match the installed extension version.

## Changes
- make 0.2.0 + companion 0.2.0 the primary public path
- expose a clear compatibility table for 0.2.0 and reviewer/candidate 0.2.2
- document the version-specific Windows installer and local ports
- prevent users from installing companion 0.2.2 before Chrome itself updates

## Validation
- HTML/JSON-LD/internal anchors and sitemap validated
- Store and versioned release links return successfully
- diff check passes