### PR TITLE
docs: align Hermes Connector support with Store 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,120 +7,89 @@ automation browser or guessing which tab belongs to which task.
 
 ![Hermes Connector — local AI, your tabs](store/promo-marquee-1400x560.png)
 
-[**Install from the Chrome Web Store**](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm)
-· [Setup guide](https://corsenai.github.io/hermes-connector/)
-· [Download companion 0.2.1](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip)
-· [Get support](https://corsenai.github.io/hermes-connector/support/)
+[**Install version 0.2.2 from the Chrome Web Store**](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm)
+· [Download companion 0.2.2](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip)
+· [Setup and support](https://corsenai.github.io/hermes-connector/support/)
+· [Privacy policy](https://corsenai.github.io/hermes-connector/privacy/)
 
 > Unofficial community project by Corsen AI. Not affiliated with or endorsed
 > by Nous Research or Google.
 
-![Hermes Connector demo showing explicit tab scope and browser actions](marketing/video/hermes-connector-demo.gif)
+## Current release
 
-## Your Hermes session, inside the Chrome you already use
+The public Chrome Web Store release is **0.2.2**. The extension and local
+companion must have exactly the same version.
+
+| Chrome extension | Matching companion | Protocol / default broker | Status |
+| --- | --- | --- | --- |
+| 0.2.2 | [Companion 0.2.2](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip) | Protocol 4 / `127.0.0.1:8766` | Current public release |
+| 0.2.1 | [Companion 0.2.1](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip) | Protocol 4 / `127.0.0.1:8766` | Legacy released/sideloaded pair |
+| 0.2.0 | [Companion 0.2.0](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip) | Protocol 3 / `127.0.0.1:8765` | Legacy pair; see disk-recovery note |
+
+Do not mix versions. Check `chrome://extensions` before installing a companion.
+The complete compatibility, upgrade, and version 0.2.0 LevelDB recovery guide
+is available on the [support page](https://corsenai.github.io/hermes-connector/support/).
+
+## What it does
 
 Hermes Connector embeds the real local Hermes dashboard in Chrome's side panel.
 You decide which tabs each Hermes session may access, and the connector keeps
-that scope exact even when several projects, sessions, or Chrome profiles are
-running at the same time.
-
-![Hermes Connector controlling an explicitly attached Chrome tab from the side panel](store/screenshot-product-1280x800.png)
+that scope exact even when several projects, sessions, or Chrome profiles run at
+the same time.
 
 With an attached tab, Hermes can:
 
 - inspect and read the visible page;
 - navigate, click, type, scroll, hover, select, drag, and use keyboard actions;
 - find text, use browser history, and take requested screenshots;
-- open, list, switch, and close tabs inside that session's authorized scope;
+- open, list, switch, and close tabs inside the session's authorized scope;
 - keep concurrent Hermes projects isolated from one another.
 
-This is real browser control with an explicit boundary: a tab is unavailable to
-Hermes until you attach it. If a Hermes session has no attached target, its
-browser action fails visibly instead of falling back to the last active tab.
+There is no fallback to the globally active or most recently used tab. If a
+Hermes session has no attached target, its browser action fails visibly.
 
-## Why the routing stays precise
-
-| You choose | Hermes Connector guarantees |
-| --- | --- |
-| A real Hermes profile and session | Every browser request is routed back to that exact session. |
-| One or more Chrome tabs | Only those attached tabs can be read or controlled. |
-| A named Chrome profile | Its local browser identity remains distinct from other Chrome profiles. |
-| Whether to enable Trusted input | Chrome's debugger transport stays off unless you explicitly enable it. |
-
-The result is useful for everyday browsing as well as parallel agent workflows:
-your authenticated websites remain available in your normal Chrome profile,
-while each Hermes task receives only the tabs assigned to it.
-
-## Quick start
-
-You need a local Hermes Agent installation, desktop Chrome 120 or newer, and the
-small Hermes Connector companion. The extension's first-run screen detects your
-operating system, checks whether the companion is already reachable, and shows
-the appropriate Windows, macOS, or Linux instructions.
+## Install version 0.2.2
 
 ### 1. Install the Chrome extension
 
-[Install Hermes Connector from the Chrome Web Store](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm),
-then click its toolbar icon or press `Ctrl+Shift+H` (`Command+Shift+H` on macOS)
-to open the side panel.
+Install Hermes Connector from the
+[Chrome Web Store](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm),
+then verify that `chrome://extensions` shows version **0.2.2**.
 
-### 2. Let the extension check the companion
+### 2. Install the matching companion
 
-On first launch, Hermes Connector checks only your computer's loopback address.
-It does not send this check to the internet.
+Download and extract
+[`hermes-connector-0.2.2-companion.zip`](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip).
 
-- If the panel says the companion is already reachable, do not reinstall it.
-- Otherwise, use the panel's **Download companion** button and extract the ZIP.
+On Windows, double-click `Install Hermes Connector.cmd`, or run:
 
-The current matching download is
-[`hermes-connector-0.2.1-companion.zip`](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip).
+```powershell
+.\install.ps1
+```
 
-### 3. Install the companion once
-
-**Windows:** double-click `Install Hermes Connector.cmd` in the extracted
-folder. Keep the result window open so you can copy the pairing code.
-
-**macOS or Linux:** open a terminal in the extracted folder and run:
+On macOS or Linux, run:
 
 ```sh
 ./install.sh
 ```
 
-Restart any Hermes dashboard, gateway, or chat process that was already
-running. The installer adds the connector plugin to the shared Hermes home and
-existing named profiles, then prints one private pairing code.
+Restart every running Hermes dashboard, gateway, or chat process. Re-run the
+installer after creating a new named Hermes profile.
 
-### 4. Pair Chrome and choose the tabs
+### 3. Pair Chrome and choose the tabs
 
 In the Hermes Connector side panel:
 
 1. Give this Chrome profile a recognizable name.
-2. Paste the pairing code printed by the installer and save.
+2. Paste the private pairing code printed by the installer.
 3. Select the Hermes profile and session you want to use.
 4. Choose **Attach active tab** or **Choose tabs**.
 5. Ask Hermes to work with the selected page.
 
-For example:
+Tab titles and URLs are displayed locally when you open **Choose tabs**, so you
+make the authorization decision yourself.
 
-```text
-Read the release checklist in my attached tab and tell me what remains.
-```
-
-or:
-
-```text
-Click the requested action in my attached tab, then explain what changed.
-```
-
-Tab titles and URLs are displayed locally when you open **Choose tabs** so that
-you can make the selection yourself.
-
-## Why a companion is required
-
-A Chrome extension cannot register browser tools directly inside a local Hermes
-installation. The companion installs that Hermes-side plugin and runs the
-authenticated loopback broker used by the extension. It is bundled in the
-public release archive and does not create a Corsen AI cloud relay.
+## Architecture
 
 ```text
 Hermes profile and session
@@ -131,47 +100,30 @@ Hermes profile and session
   -> requested browser action
 ```
 
-Chrome automatically updates the Store extension. It cannot update a local
-companion, so after an extension protocol upgrade the panel keeps a clear
-update notice visible until you confirm that the matching companion was
-installed. If you remove and reinstall the extension, or add it to another
-Chrome profile, the first-run check detects an already-running companion and
-avoids asking you to install it again.
+The extension and companion use role-bound mutual HMAC authentication. The
+pairing secret is not transmitted over the loopback connection.
 
 ## Privacy and security
 
 Hermes Connector is designed to keep authority visible and local:
 
-- no Corsen AI relay, account, advertising, analytics, tracking, or telemetry;
+- no Corsen AI relay, cloud account, advertising, analytics, tracking, or telemetry;
 - loopback-only connector transport on `127.0.0.1`;
 - explicit tab attachment and exact session-to-tab authorization;
 - separate persistent identities for separate Chrome profiles;
 - role-bound mutual HMAC authentication without sending the pairing secret;
 - sensitive form-field and URL-secret redaction in browser snapshots;
 - bounded protocol messages and fail-closed routing;
-- Trusted input disabled by default, with Chrome's debugger banner visible when
-  you enable it for reliable native input or dialog handling.
+- Trusted input disabled by default, with Chrome's debugger banner visible when enabled.
 
 Page content is sent to the user's local Hermes installation. A remote model
-provider receives it only if the user has configured Hermes to use that
-provider. Attach only tabs you are comfortable sharing with that configuration.
+provider receives it only if the user configured Hermes to use that provider.
+Attach only tabs you are comfortable sharing with that configuration.
 
-Read the full [privacy policy](PRIVACY.md), [product specification](docs/PRODUCT-SPEC.md),
-and [acceptance gates](docs/ACCEPTANCE.md).
-
-## Project structure
-
-- `extension/`: reviewable Manifest V3 Chrome extension.
-- `hermes-plugin/`: cross-platform Hermes companion and local broker.
-- `scripts/`: installation, packaging, and deterministic release tooling.
-- `tests/`: routing, installer, security, UI-module, and live-browser tests.
-- `docs/`: product contract, architecture, setup, and release acceptance gates.
-- `store/`: Chrome Web Store copy and approved visual assets.
+Read [PRIVACY.md](PRIVACY.md), [docs/PRODUCT-SPEC.md](docs/PRODUCT-SPEC.md), and
+[docs/ACCEPTANCE.md](docs/ACCEPTANCE.md).
 
 ## Build and verify
-
-The normal Store installation does not require Developer mode. The following
-commands are only for contributors and release verification.
 
 Run the isolated test gate:
 
@@ -179,13 +131,13 @@ Run the isolated test gate:
 & "$env:LOCALAPPDATA\hermes\hermes-agent\venv\Scripts\python.exe" tests\run_all.py
 ```
 
-Run live extension acceptance with Chromium or Chrome for Testing:
+Run live extension acceptance:
 
 ```powershell
 & "$env:LOCALAPPDATA\hermes\hermes-agent\venv\Scripts\python.exe" tests\e2e_chromium.py
 ```
 
-Run the two-profile isolation and ownership-transfer acceptance test:
+Run two-profile isolation and ownership-transfer acceptance:
 
 ```powershell
 & "$env:LOCALAPPDATA\hermes\hermes-agent\venv\Scripts\python.exe" tests\e2e_multi_browser.py
@@ -196,11 +148,10 @@ the fast tests, produces deterministic allowlisted ZIPs, and records SHA-256
 hashes in `dist/release-<version>.json`. Explicit `-AllowDirty` development
 builds are isolated under `dist/dev/` and must not be uploaded to the Store.
 
-## Support and transparency
+## Support
 
 - [Chrome Web Store listing](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm)
-- [Setup and downloads](https://corsenai.github.io/hermes-connector/)
-- [Troubleshooting and support](https://corsenai.github.io/hermes-connector/support/)
+- [Setup, version compatibility, and troubleshooting](https://corsenai.github.io/hermes-connector/support/)
 - [Privacy policy](https://corsenai.github.io/hermes-connector/privacy/)
 - [Source code and releases](https://github.com/CorsenAI/hermes-connector)
 

--- a/README.md
+++ b/README.md
@@ -8,88 +8,136 @@ automation browser or guessing which tab belongs to which task.
 ![Hermes Connector — local AI, your tabs](store/promo-marquee-1400x560.png)
 
 [**Install version 0.2.2 from the Chrome Web Store**](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm)
+· [Setup guide](https://corsenai.github.io/hermes-connector/)
 · [Download companion 0.2.2](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip)
-· [Setup and support](https://corsenai.github.io/hermes-connector/support/)
-· [Privacy policy](https://corsenai.github.io/hermes-connector/privacy/)
+· [Get support](https://corsenai.github.io/hermes-connector/support/)
 
 > Unofficial community project by Corsen AI. Not affiliated with or endorsed
 > by Nous Research or Google.
 
-## Current release
+## Current release and compatibility
 
-The public Chrome Web Store release is **0.2.2**. The extension and local
-companion must have exactly the same version.
+The public Chrome Web Store release is **0.2.2**. The Chrome extension and local
+companion must use exactly the same version.
 
 | Chrome extension | Matching companion | Protocol / default broker | Status |
 | --- | --- | --- | --- |
 | 0.2.2 | [Companion 0.2.2](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip) | Protocol 4 / `127.0.0.1:8766` | Current public release |
-| 0.2.1 | [Companion 0.2.1](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip) | Protocol 4 / `127.0.0.1:8766` | Legacy released/sideloaded pair |
-| 0.2.0 | [Companion 0.2.0](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip) | Protocol 3 / `127.0.0.1:8765` | Legacy pair; see disk-recovery note |
+| 0.2.1 | [Companion 0.2.1](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip) | Protocol 4 / `127.0.0.1:8766` | Legacy released or sideloaded pair |
+| 0.2.0 | [Companion 0.2.0](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip) | Protocol 3 / `127.0.0.1:8765` | Legacy pair; see the disk-recovery procedure |
 
 Do not mix versions. Check `chrome://extensions` before installing a companion.
 The complete compatibility, upgrade, and version 0.2.0 LevelDB recovery guide
 is available on the [support page](https://corsenai.github.io/hermes-connector/support/).
 
-## What it does
+![Hermes Connector demo showing explicit tab scope and browser actions](marketing/video/hermes-connector-demo.gif)
+
+## Your Hermes session, inside the Chrome you already use
 
 Hermes Connector embeds the real local Hermes dashboard in Chrome's side panel.
 You decide which tabs each Hermes session may access, and the connector keeps
-that scope exact even when several projects, sessions, or Chrome profiles run at
-the same time.
+that scope exact even when several projects, sessions, or Chrome profiles are
+running at the same time.
+
+![Hermes Connector controlling an explicitly attached Chrome tab from the side panel](store/screenshot-product-1280x800.png)
 
 With an attached tab, Hermes can:
 
 - inspect and read the visible page;
 - navigate, click, type, scroll, hover, select, drag, and use keyboard actions;
 - find text, use browser history, and take requested screenshots;
-- open, list, switch, and close tabs inside the session's authorized scope;
+- open, list, switch, and close tabs inside that session's authorized scope;
 - keep concurrent Hermes projects isolated from one another.
 
-There is no fallback to the globally active or most recently used tab. If a
-Hermes session has no attached target, its browser action fails visibly.
+This is real browser control with an explicit boundary: a tab is unavailable to
+Hermes until you attach it. If a Hermes session has no attached target, its
+browser action fails visibly instead of falling back to the last active tab.
 
-## Install version 0.2.2
+## Why the routing stays precise
+
+| You choose | Hermes Connector guarantees |
+| --- | --- |
+| A real Hermes profile and session | Every browser request is routed back to that exact session. |
+| One or more Chrome tabs | Only those attached tabs can be read or controlled. |
+| A named Chrome profile | Its local browser identity remains distinct from other Chrome profiles. |
+| Whether to enable Trusted input | Chrome's debugger transport stays off unless you explicitly enable it. |
+
+The result is useful for everyday browsing as well as parallel agent workflows:
+your authenticated websites remain available in your normal Chrome profile,
+while each Hermes task receives only the tabs assigned to it.
+
+## Quick start
+
+You need a local Hermes Agent installation, desktop Chrome 120 or newer, and the
+small Hermes Connector companion. The extension's first-run screen detects your
+operating system, checks whether the companion is already reachable, and shows
+the appropriate Windows, macOS, or Linux instructions.
 
 ### 1. Install the Chrome extension
 
-Install Hermes Connector from the
-[Chrome Web Store](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm),
-then verify that `chrome://extensions` shows version **0.2.2**.
+[Install Hermes Connector from the Chrome Web Store](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm),
+verify that `chrome://extensions` shows version **0.2.2**, then click its toolbar
+icon or press `Ctrl+Shift+H` (`Command+Shift+H` on macOS) to open the side panel.
 
-### 2. Install the matching companion
+### 2. Let the extension check the companion
 
-Download and extract
+On first launch, Hermes Connector checks only your computer's loopback address.
+It does not send this check to the internet.
+
+- If the panel says the matching companion is already reachable, do not reinstall it.
+- Otherwise, use the panel's **Download companion** button and extract the ZIP.
+
+The current matching download is
 [`hermes-connector-0.2.2-companion.zip`](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip).
 
-On Windows, double-click `Install Hermes Connector.cmd`, or run:
+### 3. Install the companion once
 
-```powershell
-.\install.ps1
-```
+**Windows:** double-click `Install Hermes Connector.cmd` in the extracted
+folder, or run `\.\install.ps1` from PowerShell. Keep the result window open so
+you can copy the pairing code.
 
-On macOS or Linux, run:
+**macOS or Linux:** open a terminal in the extracted folder and run:
 
 ```sh
 ./install.sh
 ```
 
-Restart every running Hermes dashboard, gateway, or chat process. Re-run the
+Restart any Hermes dashboard, gateway, or chat process that was already
+running. The installer adds the connector plugin to the shared Hermes home and
+existing named profiles, then prints one private pairing code. Re-run the
 installer after creating a new named Hermes profile.
 
-### 3. Pair Chrome and choose the tabs
+### 4. Pair Chrome and choose the tabs
 
 In the Hermes Connector side panel:
 
 1. Give this Chrome profile a recognizable name.
-2. Paste the private pairing code printed by the installer.
+2. Paste the pairing code printed by the installer and save.
 3. Select the Hermes profile and session you want to use.
 4. Choose **Attach active tab** or **Choose tabs**.
 5. Ask Hermes to work with the selected page.
 
-Tab titles and URLs are displayed locally when you open **Choose tabs**, so you
-make the authorization decision yourself.
+For example:
 
-## Architecture
+```text
+Read the release checklist in my attached tab and tell me what remains.
+```
+
+or:
+
+```text
+Click the requested action in my attached tab, then explain what changed.
+```
+
+Tab titles and URLs are displayed locally when you open **Choose tabs** so that
+you can make the selection yourself.
+
+## Why a companion is required
+
+A Chrome extension cannot register browser tools directly inside a local Hermes
+installation. The companion installs that Hermes-side plugin and runs the
+authenticated loopback broker used by the extension. It is bundled in the
+public release archive and does not create a Corsen AI cloud relay.
 
 ```text
 Hermes profile and session
@@ -100,30 +148,47 @@ Hermes profile and session
   -> requested browser action
 ```
 
-The extension and companion use role-bound mutual HMAC authentication. The
-pairing secret is not transmitted over the loopback connection.
+Chrome automatically updates the Store extension. It cannot update a local
+companion, so after an extension version change you must install the companion
+with exactly the same version and restart Hermes. If you remove and reinstall
+the extension, or add it to another Chrome profile, the first-run check detects
+an already-running compatible companion and avoids asking you to install it
+again.
 
 ## Privacy and security
 
 Hermes Connector is designed to keep authority visible and local:
 
-- no Corsen AI relay, cloud account, advertising, analytics, tracking, or telemetry;
+- no Corsen AI relay, account, advertising, analytics, tracking, or telemetry;
 - loopback-only connector transport on `127.0.0.1`;
 - explicit tab attachment and exact session-to-tab authorization;
 - separate persistent identities for separate Chrome profiles;
 - role-bound mutual HMAC authentication without sending the pairing secret;
 - sensitive form-field and URL-secret redaction in browser snapshots;
 - bounded protocol messages and fail-closed routing;
-- Trusted input disabled by default, with Chrome's debugger banner visible when enabled.
+- Trusted input disabled by default, with Chrome's debugger banner visible when
+  you enable it for reliable native input or dialog handling.
 
 Page content is sent to the user's local Hermes installation. A remote model
-provider receives it only if the user configured Hermes to use that provider.
-Attach only tabs you are comfortable sharing with that configuration.
+provider receives it only if the user has configured Hermes to use that
+provider. Attach only tabs you are comfortable sharing with that configuration.
 
-Read [PRIVACY.md](PRIVACY.md), [docs/PRODUCT-SPEC.md](docs/PRODUCT-SPEC.md), and
-[docs/ACCEPTANCE.md](docs/ACCEPTANCE.md).
+Read the full [privacy policy](PRIVACY.md), [product specification](docs/PRODUCT-SPEC.md),
+and [acceptance gates](docs/ACCEPTANCE.md).
+
+## Project structure
+
+- `extension/`: reviewable Manifest V3 Chrome extension.
+- `hermes-plugin/`: cross-platform Hermes companion and local broker.
+- `scripts/`: installation, packaging, and deterministic release tooling.
+- `tests/`: routing, installer, security, UI-module, and live-browser tests.
+- `docs/`: product contract, architecture, setup, and release acceptance gates.
+- `store/`: Chrome Web Store copy and approved visual assets.
 
 ## Build and verify
+
+The normal Store installation does not require Developer mode. The following
+commands are only for contributors and release verification.
 
 Run the isolated test gate:
 
@@ -131,13 +196,13 @@ Run the isolated test gate:
 & "$env:LOCALAPPDATA\hermes\hermes-agent\venv\Scripts\python.exe" tests\run_all.py
 ```
 
-Run live extension acceptance:
+Run live extension acceptance with Chromium or Chrome for Testing:
 
 ```powershell
 & "$env:LOCALAPPDATA\hermes\hermes-agent\venv\Scripts\python.exe" tests\e2e_chromium.py
 ```
 
-Run two-profile isolation and ownership-transfer acceptance:
+Run the two-profile isolation and ownership-transfer acceptance test:
 
 ```powershell
 & "$env:LOCALAPPDATA\hermes\hermes-agent\venv\Scripts\python.exe" tests\e2e_multi_browser.py
@@ -148,10 +213,11 @@ the fast tests, produces deterministic allowlisted ZIPs, and records SHA-256
 hashes in `dist/release-<version>.json`. Explicit `-AllowDirty` development
 builds are isolated under `dist/dev/` and must not be uploaded to the Store.
 
-## Support
+## Support and transparency
 
 - [Chrome Web Store listing](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm)
-- [Setup, version compatibility, and troubleshooting](https://corsenai.github.io/hermes-connector/support/)
+- [Setup and downloads](https://corsenai.github.io/hermes-connector/)
+- [Version compatibility, upgrade, and troubleshooting](https://corsenai.github.io/hermes-connector/support/)
 - [Privacy policy](https://corsenai.github.io/hermes-connector/privacy/)
 - [Source code and releases](https://github.com/CorsenAI/hermes-connector)
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The current matching download is
 ### 3. Install the companion once
 
 **Windows:** double-click `Install Hermes Connector.cmd` in the extracted
-folder, or run `\.\install.ps1` from PowerShell. Keep the result window open so
+folder, or run `.\install.ps1` from PowerShell. Keep the result window open so
 you can copy the pairing code.
 
 **macOS or Linux:** open a terminal in the extracted folder and run:

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Hermes Connector — Chrome Browser Extension for Hermes Agent</title>
-  <meta name="description" content="Connect exact local Hermes Agent sessions to only the Chrome tabs you choose, using your real signed-in profile and an authenticated local companion.">
+  <meta name="description" content="Connect Hermes Agent to the Chrome tabs you choose. Use your real signed-in profile with exact session-to-tab routing and a local authenticated companion.">
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
   <meta name="theme-color" content="#080c18">
   <link rel="canonical" href="https://corsenai.github.io/hermes-connector/">
@@ -42,7 +42,10 @@
     "description": "An unofficial Chrome browser extension that connects exact local Hermes Agent sessions to user-selected tabs in a real signed-in Chrome profile.",
     "image": "https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/store-icon-128.png",
     "softwareRequirements": "Google Chrome 120 or later, a local Hermes installation, and the matching Hermes Connector companion",
-    "publisher": {"@type": "Organization", "name": "Corsen AI"},
+    "publisher": {
+      "@type": "Organization",
+      "name": "Corsen AI"
+    },
     "sameAs": [
       "https://github.com/CorsenAI/hermes-connector",
       "https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm"
@@ -57,25 +60,195 @@
   </script>
 
   <style>
-    :root{color-scheme:dark;--bg:#070a13;--surface:#0d1323;--surface2:#111a31;--line:#253557;--text:#f2f6ff;--muted:#aebbd4;--cyan:#22d3ee;--blue:#4388ff;--violet:#9b5cff;--pink:#f14dc3;--green:#5ee6a8;--warn:#ffd782;--shadow:0 24px 80px rgba(0,0,0,.34);--radius:22px}
-    *{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;overflow-x:hidden;background:radial-gradient(850px 520px at 5% 0%,rgba(20,115,180,.24),transparent 66%),radial-gradient(780px 480px at 96% 8%,rgba(145,37,173,.20),transparent 64%),var(--bg);color:var(--text);font:16px/1.65 Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}
-    a{color:#8edcff}img{display:block;max-width:100%}code{padding:.14rem .4rem;border:1px solid #314268;border-radius:6px;background:#18223d;color:#f4f7ff}.wrap{width:min(1160px,calc(100% - 40px));margin:0 auto}.skip-link{position:absolute;left:16px;top:-100px;z-index:20;padding:10px 14px;border-radius:8px;background:#fff;color:#000}.skip-link:focus{top:14px}
-    header{position:sticky;top:0;z-index:10;border-bottom:1px solid rgba(69,91,132,.45);background:rgba(7,10,19,.82);backdrop-filter:blur(18px)}nav{min-height:72px;display:flex;align-items:center;justify-content:space-between;gap:24px}.brand{display:inline-flex;align-items:center;gap:11px;color:var(--text);text-decoration:none;font-weight:800;letter-spacing:-.02em}.brand img{width:38px;height:38px;border-radius:10px;box-shadow:0 0 24px rgba(41,194,255,.24)}.nav-links{display:flex;align-items:center;gap:22px}.nav-links a{color:#c9d4e9;text-decoration:none;font-weight:650;font-size:14px}.nav-links a:hover{color:#fff}
-    .hero{padding:86px 0 54px}.hero-grid{display:grid;grid-template-columns:1.02fr .98fr;align-items:center;gap:clamp(38px,7vw,88px)}.eyebrow,.kicker{margin:0 0 12px;color:#8ce8fb;font-size:13px;font-weight:850;letter-spacing:.13em;text-transform:uppercase}.eyebrow{display:inline-flex;align-items:center;gap:9px}.eyebrow:before{content:"";width:8px;height:8px;border-radius:999px;background:var(--green);box-shadow:0 0 17px var(--green)}h1{max-width:790px;margin:0;font-size:clamp(43px,6.2vw,76px);line-height:.98;letter-spacing:-.057em}.gradient-text{color:transparent;background:linear-gradient(98deg,#51dfff 7%,#6a8cff 45%,#ec65d0 93%);background-clip:text;-webkit-background-clip:text}.lead{max-width:670px;margin:25px 0 0;color:#c5d1e7;font-size:clamp(18px,2vw,21px);line-height:1.55}.actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:31px}.button{display:inline-flex;align-items:center;justify-content:center;min-height:50px;padding:12px 19px;border:1px solid #33466f;border-radius:12px;background:rgba(17,26,49,.86);color:var(--text);text-decoration:none;font-weight:800;transition:transform .18s ease,border-color .18s ease,box-shadow .18s ease}.button:hover{transform:translateY(-2px);border-color:#6a86b9}.button:focus-visible,a:focus-visible,summary:focus-visible{outline:3px solid #77d9ff;outline-offset:3px}.button.primary{border-color:transparent;background:linear-gradient(100deg,#287eff,#a94cea 72%,#e647bd);box-shadow:0 13px 36px rgba(94,85,246,.30)}.microcopy{margin-top:13px;color:var(--muted);font-size:13px}
-    .product-frame{overflow:hidden;border:1px solid #344970;border-radius:19px;background:#090f1c;box-shadow:var(--shadow);transform:perspective(1300px) rotateY(-3deg) rotateX(1deg)}.product-frame figcaption{padding:11px 15px;border-top:1px solid #253454;color:#9facbf;font-size:12px}
-    .release-card{margin-top:36px;padding:27px;border:1px solid #337760;border-radius:var(--radius);background:radial-gradient(500px 230px at 0 0,rgba(61,226,173,.12),transparent 70%),linear-gradient(155deg,rgba(15,42,38,.98),rgba(10,15,28,.98));display:grid;grid-template-columns:1fr auto;gap:24px;align-items:center}.release-card h2{font-size:clamp(25px,3vw,34px)}.release-card p{margin:8px 0 0}.release-facts{display:grid;grid-template-columns:repeat(3,auto);gap:10px}.pill{padding:8px 11px;border:1px solid #376f62;border-radius:999px;color:#c9f7e5;background:rgba(14,51,43,.7);font-size:13px;font-weight:750;white-space:nowrap}
-    .trust-strip{margin:34px auto 0;padding:17px 20px;border:1px solid rgba(64,87,131,.65);border-radius:15px;background:rgba(13,19,35,.72);display:grid;grid-template-columns:repeat(4,1fr);gap:18px}.trust-item{text-align:center;color:#becbe0;font-size:14px}.trust-item strong{display:block;color:#fff;font-size:15px}
-    section{scroll-margin-top:98px}.section{padding:84px 0}.section-head{max-width:780px;margin-bottom:34px}.section-head h2{margin:0;font-size:clamp(31px,4vw,48px);line-height:1.08;letter-spacing:-.038em}.section-head p{margin:16px 0 0;color:var(--muted);font-size:18px}.card{border:1px solid var(--line);border-radius:var(--radius);background:linear-gradient(155deg,rgba(18,28,52,.95),rgba(10,15,28,.95));box-shadow:0 20px 55px rgba(0,0,0,.18)}.steps{display:grid;grid-template-columns:repeat(3,1fr);gap:17px}.step{position:relative;min-height:260px;padding:27px;overflow:hidden}.step-number{display:grid;place-items:center;width:42px;height:42px;margin-bottom:39px;border:1px solid #3c5a8a;border-radius:12px;background:#142441;color:#92e7fb;font-weight:900}.step h3,.feature h3{margin:0 0 9px;font-size:20px}.step p,.feature p{margin-bottom:0;color:#cbd6e9}.feature-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:18px}.feature{min-height:190px;padding:27px}.icon{display:inline-grid;place-items:center;width:38px;height:38px;margin-bottom:22px;border-radius:11px;background:linear-gradient(145deg,rgba(58,160,255,.22),rgba(198,67,226,.19));color:#a2e7ff;font-weight:900}
-    .security{display:grid;grid-template-columns:.9fr 1.1fr;gap:28px;align-items:stretch}.security-copy{padding:34px}.security-copy h2{font-size:clamp(30px,4vw,44px);line-height:1.1;margin:0}.security-copy ul{margin:25px 0 0;padding:0;list-style:none}.security-copy li{position:relative;margin:13px 0;padding-left:28px;color:#cfdaed}.security-copy li:before{content:"✓";position:absolute;left:0;color:var(--green);font-weight:900}.diagram{padding:30px;display:grid;align-content:center;gap:12px}.node{padding:14px 16px;border:1px solid #31476f;border-radius:12px;background:#111d35;color:#e8effd;font-weight:700}.arrow{text-align:center;color:#73d8ef;font-size:20px}.requirements{overflow:hidden}.req{display:grid;grid-template-columns:180px 1fr;gap:22px;padding:18px 23px;border-top:1px solid var(--line)}.req:first-child{border-top:0}.req strong{color:#fff}.req span{color:#c7d2e6}.faq{display:grid;gap:12px}.faq details{padding:19px 21px}.faq summary{cursor:pointer;font-weight:800}.faq p{margin:12px 0 0;color:#cbd6e9}.legacy{padding:26px;border-color:#715c31}.legacy .warning{color:var(--warn)}footer{padding:30px 0 48px;border-top:1px solid rgba(64,87,131,.55);color:#9facbf}.footer-inner{display:flex;justify-content:space-between;gap:24px;flex-wrap:wrap}.footer-links{display:flex;gap:16px;flex-wrap:wrap}
-    @media(max-width:900px){.hero-grid,.security{grid-template-columns:1fr}.product-frame{transform:none}.release-card{grid-template-columns:1fr}.release-facts{grid-template-columns:repeat(3,1fr)}.steps{grid-template-columns:1fr}.trust-strip{grid-template-columns:repeat(2,1fr)}}@media(max-width:650px){.wrap{width:min(100% - 28px,1160px)}.nav-links>a:not(.nav-cta){display:none}.hero{padding-top:58px}.feature-grid{grid-template-columns:1fr}.release-facts{grid-template-columns:1fr}.trust-strip{grid-template-columns:1fr}.req{grid-template-columns:1fr;gap:4px}}
+    :root {
+      color-scheme: dark;
+      --bg: #070a13;
+      --surface: #0d1323;
+      --surface-2: #111a31;
+      --line: #253557;
+      --text: #f2f6ff;
+      --muted: #aebbd4;
+      --cyan: #22d3ee;
+      --blue: #4388ff;
+      --violet: #9b5cff;
+      --pink: #f14dc3;
+      --green: #5ee6a8;
+      --shadow: 0 24px 80px rgba(0, 0, 0, .34);
+      --radius: 22px;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      overflow-x: hidden;
+      background:
+        radial-gradient(850px 520px at 5% 0%, rgba(20, 115, 180, .24), transparent 66%),
+        radial-gradient(780px 480px at 96% 8%, rgba(145, 37, 173, .20), transparent 64%),
+        var(--bg);
+      color: var(--text);
+      font: 16px/1.65 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a { color: #8edcff; }
+    img { display: block; max-width: 100%; }
+    code { padding: .14rem .4rem; border: 1px solid #314268; border-radius: 6px; background: #18223d; color: #f4f7ff; }
+    .wrap { width: min(1160px, calc(100% - 40px)); margin: 0 auto; }
+    .skip-link { position: absolute; left: 16px; top: -100px; z-index: 20; padding: 10px 14px; border-radius: 8px; background: #fff; color: #000; }
+    .skip-link:focus { top: 14px; }
+
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      border-bottom: 1px solid rgba(69, 91, 132, .45);
+      background: rgba(7, 10, 19, .82);
+      backdrop-filter: blur(18px);
+    }
+    nav { min-height: 72px; display: flex; align-items: center; justify-content: space-between; gap: 24px; }
+    .brand { display: inline-flex; align-items: center; gap: 11px; color: var(--text); text-decoration: none; font-weight: 800; letter-spacing: -.02em; }
+    .brand img { width: 38px; height: 38px; border-radius: 10px; box-shadow: 0 0 24px rgba(41, 194, 255, .24); }
+    .nav-links { display: flex; align-items: center; gap: 22px; }
+    .nav-links a { color: #c9d4e9; text-decoration: none; font-weight: 650; font-size: 14px; }
+    .nav-links a:hover { color: #fff; }
+
+    .hero { padding: 86px 0 54px; }
+    .hero-grid { display: grid; grid-template-columns: 1.02fr .98fr; align-items: center; gap: clamp(38px, 7vw, 88px); }
+    .eyebrow { display: inline-flex; align-items: center; gap: 9px; margin: 0 0 18px; color: #8ce8fb; font-size: 13px; font-weight: 850; letter-spacing: .13em; text-transform: uppercase; }
+    .eyebrow::before { content: ""; width: 8px; height: 8px; border-radius: 999px; background: var(--green); box-shadow: 0 0 17px var(--green); }
+    h1 { max-width: 790px; margin: 0; font-size: clamp(43px, 6.2vw, 76px); line-height: .98; letter-spacing: -.057em; }
+    .gradient-text { color: transparent; background: linear-gradient(98deg, #51dfff 7%, #6a8cff 45%, #ec65d0 93%); background-clip: text; -webkit-background-clip: text; }
+    .lead { max-width: 670px; margin: 25px 0 0; color: #c5d1e7; font-size: clamp(18px, 2vw, 21px); line-height: 1.55; }
+    .actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 31px; }
+    .button { display: inline-flex; align-items: center; justify-content: center; min-height: 50px; padding: 12px 19px; border: 1px solid #33466f; border-radius: 12px; background: rgba(17, 26, 49, .86); color: var(--text); text-decoration: none; font-weight: 800; transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease; }
+    .button:hover { transform: translateY(-2px); border-color: #6a86b9; }
+    .button:focus-visible, a:focus-visible, summary:focus-visible { outline: 3px solid #77d9ff; outline-offset: 3px; }
+    .button.primary { border-color: transparent; background: linear-gradient(100deg, #287eff, #a94cea 72%, #e647bd); box-shadow: 0 13px 36px rgba(94, 85, 246, .30); }
+    .button.primary:hover { box-shadow: 0 17px 44px rgba(115, 74, 240, .42); }
+    .microcopy { margin-top: 13px; color: var(--muted); font-size: 13px; }
+
+    .card.transition { margin-top: 34px; padding: 27px; border-color: #31745d; background: radial-gradient(500px 230px at 0% 0%, rgba(61, 226, 173, .12), transparent 70%), linear-gradient(155deg, rgba(15, 42, 38, .98), rgba(10, 15, 28, .98)); }
+    .transition h2 { font-size: clamp(25px, 3vw, 34px); }
+    .transition > p { margin: 11px 0; }
+    .transition .warning { color: #ffe0a0; }
+    .compatibility-scroll { overflow-x: auto; margin: 18px 0; }
+    .compatibility { width: 100%; min-width: 760px; border-collapse: collapse; }
+    .compatibility th, .compatibility td { padding: 14px 15px; border: 1px solid #34415c; text-align: left; vertical-align: top; }
+    .compatibility th { background: #18223b; color: #fff; }
+    .compatibility td { color: #d3ddef; }
+    .compatibility td strong { color: #fff; }
+
+    .hero-visual { position: relative; }
+    .hero-visual::before { content: ""; position: absolute; inset: 8% -9% -8% 15%; z-index: -1; border-radius: 50%; background: radial-gradient(circle, rgba(74, 122, 255, .28), rgba(218, 51, 213, .10) 42%, transparent 70%); filter: blur(18px); }
+    .product-frame { overflow: hidden; border: 1px solid #344970; border-radius: 19px; background: #090f1c; box-shadow: var(--shadow); transform: perspective(1300px) rotateY(-3deg) rotateX(1deg); }
+    .product-frame img { width: 100%; height: auto; }
+    .product-frame figcaption { padding: 11px 15px; border-top: 1px solid #253454; color: #9facbf; font-size: 12px; }
+
+    .trust-strip { margin: 44px auto 0; padding: 17px 20px; border: 1px solid rgba(64, 87, 131, .65); border-radius: 15px; background: rgba(13, 19, 35, .72); display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+    .trust-item { text-align: center; color: #becbe0; font-size: 14px; }
+    .trust-item strong { display: block; color: #fff; font-size: 15px; }
+
+    section { scroll-margin-top: 98px; }
+    .section { padding: 84px 0; }
+    .section-head { max-width: 760px; margin-bottom: 34px; }
+    .kicker { margin: 0 0 7px; color: var(--cyan); font-size: 13px; font-weight: 850; letter-spacing: .12em; text-transform: uppercase; }
+    h2 { margin: 0; font-size: clamp(31px, 4vw, 48px); line-height: 1.08; letter-spacing: -.038em; }
+    .section-head p { margin: 16px 0 0; color: var(--muted); font-size: 18px; }
+    h3 { margin: 0 0 9px; font-size: 20px; letter-spacing: -.02em; }
+    p { color: #cbd6e9; }
+
+    .steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 17px; }
+    .card { border: 1px solid var(--line); border-radius: var(--radius); background: linear-gradient(155deg, rgba(18, 28, 52, .95), rgba(10, 15, 28, .95)); box-shadow: 0 20px 55px rgba(0, 0, 0, .18); }
+    .step { position: relative; min-height: 260px; padding: 27px; overflow: hidden; }
+    .step-number { display: grid; place-items: center; width: 42px; height: 42px; margin-bottom: 39px; border: 1px solid #3c5a8a; border-radius: 12px; background: #142441; color: #92e7fb; font-weight: 900; }
+    .step p { margin-bottom: 0; }
+    .step a { font-weight: 700; }
+    .step::after { content: ""; position: absolute; width: 150px; height: 150px; right: -68px; bottom: -85px; border-radius: 50%; background: var(--glow, rgba(53, 208, 255, .14)); filter: blur(8px); }
+
+    .feature-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+    .feature { min-height: 190px; padding: 27px; }
+    .icon { display: inline-grid; place-items: center; width: 38px; height: 38px; margin-bottom: 22px; border-radius: 11px; background: linear-gradient(145deg, rgba(58, 160, 255, .22), rgba(198, 67, 226, .19)); color: #a2e7ff; font-weight: 900; }
+    .feature p { margin-bottom: 0; }
+
+    .security { display: grid; grid-template-columns: .9fr 1.1fr; gap: 28px; align-items: stretch; }
+    .security-copy { padding: 34px; }
+    .security-copy h2 { font-size: clamp(30px, 4vw, 44px); }
+    .security-copy ul { margin: 25px 0 0; padding: 0; list-style: none; }
+    .security-copy li { position: relative; margin: 13px 0; padding-left: 28px; color: #cfdaed; }
+    .security-copy li::before { content: "✓"; position: absolute; left: 0; color: var(--green); font-weight: 900; }
+    .security-note { padding: 31px; border: 1px solid #384775; border-radius: var(--radius); background: radial-gradient(420px 220px at 90% 0%, rgba(171, 70, 219, .18), transparent 70%), #10172a; }
+    .security-note p:last-child { margin-bottom: 0; }
+
+    .requirements { overflow: hidden; }
+    .requirements-row { display: grid; grid-template-columns: 180px 1fr; gap: 26px; padding: 21px 26px; border-bottom: 1px solid #263653; }
+    .requirements-row:last-child { border-bottom: 0; }
+    .requirements-row strong { color: #fff; }
+    .requirements-row span { color: #c8d4e8; }
+
+    .faq { display: grid; grid-template-columns: .7fr 1.3fr; gap: 46px; align-items: start; }
+    .faq-list { display: grid; gap: 12px; }
+    details { border: 1px solid var(--line); border-radius: 15px; background: rgba(15, 23, 42, .78); }
+    summary { cursor: pointer; padding: 19px 21px; color: #f4f7ff; font-weight: 800; }
+    details p { margin: 0; padding: 0 21px 20px; }
+
+    .final-cta { padding: 48px; text-align: center; background: radial-gradient(520px 240px at 50% 0%, rgba(53, 151, 255, .23), transparent 70%), linear-gradient(145deg, #111a32, #0c1221); }
+    .final-cta p { max-width: 690px; margin: 14px auto 0; color: #bdc9df; font-size: 18px; }
+    .final-cta .actions { justify-content: center; }
+
+    footer { margin-top: 88px; border-top: 1px solid #202d48; padding: 31px 0 42px; color: var(--muted); font-size: 14px; }
+    .footer-grid { display: flex; justify-content: space-between; gap: 30px; align-items: flex-start; }
+    .footer-links { display: flex; flex-wrap: wrap; gap: 17px; }
+    footer a { color: #c5d4ea; }
+    .legal { max-width: 640px; margin: 12px 0 0; color: #8f9db5; font-size: 13px; }
+
+    @media (max-width: 900px) {
+      .hero-grid, .security, .faq { grid-template-columns: 1fr; }
+      .hero-visual { max-width: 740px; }
+      .product-frame { transform: none; }
+      .steps { grid-template-columns: 1fr; }
+      .step { min-height: auto; }
+      .step-number { margin-bottom: 24px; }
+      .trust-strip { grid-template-columns: repeat(2, 1fr); }
+      .faq { gap: 25px; }
+    }
+
+    @media (max-width: 640px) {
+      .wrap { width: min(100% - 28px, 1160px); }
+      .nav-links a:not(.nav-cta) { display: none; }
+      .hero { padding-top: 58px; }
+      h1 { font-size: clamp(42px, 14vw, 58px); }
+      .feature-grid, .trust-strip { grid-template-columns: 1fr; }
+      .trust-item { text-align: left; }
+      .section { padding: 65px 0; }
+      .security-copy, .security-note, .final-cta { padding: 26px; }
+      .requirements-row { grid-template-columns: 1fr; gap: 5px; }
+      .footer-grid { flex-direction: column; }
+      .button { width: 100%; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      *, *::before, *::after { transition-duration: .01ms !important; }
+    }
   </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
-  <header><nav class="wrap" aria-label="Primary navigation">
-    <a class="brand" href="./" aria-label="Hermes Connector home"><img src="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/store-icon-128.png" width="38" height="38" alt=""><span>Hermes Connector</span></a>
-    <div class="nav-links"><a href="#how-it-works">How it works</a><a href="#security">Security</a><a href="#faq">FAQ</a><a class="button nav-cta" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Install for Chrome</a></div>
-  </nav></header>
+  <header>
+    <nav class="wrap" aria-label="Primary navigation">
+      <a class="brand" href="./" aria-label="Hermes Connector home">
+        <img src="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/store-icon-128.png" width="38" height="38" alt="">
+        <span>Hermes Connector</span>
+      </a>
+      <div class="nav-links">
+        <a href="#how-it-works">How it works</a>
+        <a href="#security">Security</a>
+        <a href="#faq">FAQ</a>
+        <a class="button nav-cta" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Install for Chrome</a>
+      </div>
+    </nav>
+  </header>
 
   <main id="main">
     <section class="hero">
@@ -84,63 +257,198 @@
           <p class="eyebrow">Chrome browser extension for Hermes Agent</p>
           <h1>Your Hermes session. <span class="gradient-text">Your chosen tabs.</span></h1>
           <p class="lead">Hermes Connector links exact local Hermes Agent sessions to only the Chrome tabs you attach—inside the signed-in browser profile you already use.</p>
-          <div class="actions"><a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add version 0.2.2 to Chrome</a><a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a></div>
-          <p class="microcopy">Current public pair: extension 0.2.2 + companion 0.2.2 · Windows, macOS, and Linux</p>
+          <div class="actions">
+            <a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add to Chrome</a>
+            <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a>
+          </div>
+          <p class="microcopy">Current public pair: extension 0.2.2 + companion 0.2.2</p>
         </div>
-        <figure class="product-frame"><img src="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/screenshot-product-1280x800.png" width="1280" height="800" alt="Hermes Connector side panel attached to a selected Chrome tab" fetchpriority="high"><figcaption>Each Hermes session can act only on tabs explicitly attached to it.</figcaption></figure>
+
+        <figure class="product-frame hero-visual">
+          <img src="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/screenshot-product-1280x800.png" width="1280" height="800" alt="Hermes Connector side panel attached to the Project Atlas tab in Chrome" fetchpriority="high">
+          <figcaption>Hermes Connector routes the selected Hermes session to its explicitly attached tab.</figcaption>
+        </figure>
       </div>
 
-      <div class="wrap release-card" role="note" aria-labelledby="release-title">
-        <div><p class="kicker">Current Chrome Web Store release</p><h2 id="release-title">Version 0.2.2 is public. Keep the extension and companion matched.</h2><p>Chrome updates the Store extension, but it cannot update the separately installed local companion. Install companion 0.2.2 once and restart Hermes.</p></div>
-        <div class="release-facts" aria-label="Release details"><span class="pill">Version 0.2.2</span><span class="pill">Protocol 4</span><span class="pill">Port 8766</span></div>
+      <div class="wrap card transition" role="note" aria-labelledby="version-match-title">
+        <p class="kicker">Current Chrome Web Store release</p>
+        <h2 id="version-match-title">Match the local companion to the extension version shown by Chrome.</h2>
+        <p>Open <code>chrome://extensions</code> and check Hermes Connector before downloading the local companion.</p>
+        <div class="compatibility-scroll"><table class="compatibility">
+          <thead><tr><th>Extension installed in Chrome</th><th>Compatible local companion</th><th>Use this pair when</th></tr></thead>
+          <tbody>
+            <tr><td><strong>0.2.2</strong> from the <a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">current Chrome Web Store listing</a></td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a></td><td>Normal installation and every user whose extension page shows 0.2.2.</td></tr>
+            <tr><td><strong>0.2.1</strong> legacy released or sideloaded build</td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip">Download companion 0.2.1</a></td><td>Only while Chrome explicitly shows extension version 0.2.1.</td></tr>
+            <tr><td><strong>0.2.0</strong> legacy build</td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip">Download companion 0.2.0</a></td><td>Only while Chrome explicitly shows 0.2.0. Follow the <a href="support/#leveldb-recovery">disk-recovery procedure</a>.</td></tr>
+          </tbody>
+        </table></div>
+        <p class="warning"><strong>Do not mix versions.</strong> Update the extension first, then install the companion with exactly the same version. See the <a href="support/#compatible-versions">versioned setup guide</a>.</p>
       </div>
 
-      <div class="wrap trust-strip" role="list" aria-label="Product summary"><div class="trust-item" role="listitem"><strong>Exact routing</strong>Session → chosen tab</div><div class="trust-item" role="listitem"><strong>Real Chrome profile</strong>Keep existing site sessions</div><div class="trust-item" role="listitem"><strong>Local connection</strong>Authenticated loopback</div><div class="trust-item" role="listitem"><strong>Fail closed</strong>No silent fallback tab</div></div>
+      <div class="wrap trust-strip" role="list" aria-label="Product summary">
+        <div class="trust-item" role="listitem"><strong>Exact routing</strong>Session → chosen tab</div>
+        <div class="trust-item" role="listitem"><strong>Real Chrome profile</strong>Keep existing site sessions</div>
+        <div class="trust-item" role="listitem"><strong>Local connection</strong>Authenticated loopback</div>
+        <div class="trust-item" role="listitem"><strong>Fail closed</strong>No silent fallback tab</div>
+      </div>
     </section>
 
-    <section class="section" id="how-it-works"><div class="wrap">
-      <div class="section-head"><p class="kicker">Start in three steps</p><h2>Connect Chrome to Hermes without creating another browser.</h2><p>The side panel embeds your local Hermes dashboard. You keep your real Chrome profile, select the Hermes session, and decide which tabs it may use.</p></div>
-      <div class="steps">
-        <article class="card step"><div class="step-number">1</div><h3>Install the extension</h3><p><a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add Hermes Connector 0.2.2 from the Chrome Web Store</a>, then open its side panel.</p></article>
-        <article class="card step"><div class="step-number">2</div><h3>Install the local companion</h3><p>Download companion 0.2.2, run the installer once, and restart every running Hermes dashboard, gateway, or chat process.</p></article>
-        <article class="card step"><div class="step-number">3</div><h3>Pair, select, attach</h3><p>Paste the locally printed pairing code, select a real Hermes session, then attach only the tabs that session may read or control.</p></article>
+    <section class="section" id="how-it-works">
+      <div class="wrap">
+        <div class="section-head">
+          <p class="kicker">Start in three steps</p>
+          <h2>Connect Chrome to Hermes without creating another browser.</h2>
+          <p>The side panel embeds your local Hermes dashboard. You keep your real Chrome profile, choose the Hermes session, and decide which tabs it may use.</p>
+        </div>
+        <div class="steps">
+          <article class="card step" style="--glow:rgba(42,211,238,.18)">
+            <div class="step-number">1</div>
+            <h3>Install the extension</h3>
+            <p><a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add Hermes Connector from the Chrome Web Store</a>, then open its side panel.</p>
+          </article>
+          <article class="card step" style="--glow:rgba(100,107,255,.20)">
+            <div class="step-number">2</div>
+            <h3>Install the local companion</h3>
+            <p>Check the extension version, download the exact matching companion from the table above, run its installer once, and restart Hermes.</p>
+          </article>
+          <article class="card step" style="--glow:rgba(234,70,199,.18)">
+            <div class="step-number">3</div>
+            <h3>Pair, select, attach</h3>
+            <p>Paste the locally printed pairing code, select a real Hermes session, then attach only the tabs that session may read or control.</p>
+          </article>
+        </div>
       </div>
-    </div></section>
+    </section>
 
-    <section class="section" id="features"><div class="wrap">
-      <div class="section-head"><p class="kicker">Built for real workflows</p><h2>Browser control with an explicit boundary.</h2><p>Hermes receives the browser capabilities it needs without being granted every open tab indiscriminately.</p></div>
-      <div class="feature-grid">
-        <article class="card feature"><span class="icon">01</span><h3>Exact session-to-tab routing</h3><p>Every browser request returns to the selected Hermes profile, session, Chrome profile, and attached target.</p></article>
-        <article class="card feature"><span class="icon">02</span><h3>Normal signed-in Chrome</h3><p>Use existing website sessions in the Chrome profile you already operate instead of a hidden automation browser.</p></article>
-        <article class="card feature"><span class="icon">03</span><h3>Scoped browser actions</h3><p>Navigate, inspect, read, click, type, scroll, hover, select, drag, use keys, take screenshots, search pages, and manage authorized tabs.</p></article>
-        <article class="card feature"><span class="icon">04</span><h3>Concurrent project isolation</h3><p>Separate Hermes sessions and Chrome profiles can work at the same time without inheriting one another's tab scope.</p></article>
+    <section class="section" id="features">
+      <div class="wrap">
+        <div class="section-head">
+          <p class="kicker">Built for real workflows</p>
+          <h2>Browser control with an explicit boundary.</h2>
+          <p>Run simultaneous projects without accidentally sending one Hermes session into another project's browser context.</p>
+        </div>
+        <div class="feature-grid">
+          <article class="card feature">
+            <div class="icon" aria-hidden="true">↗</div>
+            <h3>Exact session-to-tab scope</h3>
+            <p>Attach one or more Chrome tabs to a specific Hermes profile and session. An unbound session is rejected instead of falling back to another tab.</p>
+          </article>
+          <article class="card feature">
+            <div class="icon" aria-hidden="true">◎</div>
+            <h3>Your signed-in browser</h3>
+            <p>Hermes works with the Chrome profile and site sessions you already use. Hermes Connector does not launch a hidden automation profile.</p>
+          </article>
+          <article class="card feature">
+            <div class="icon" aria-hidden="true">⌁</div>
+            <h3>Useful browser actions</h3>
+            <p>Navigate, inspect, read, click, type, scroll, take requested screenshots, use keys, select options, drag, search, and manage scoped tabs.</p>
+          </article>
+          <article class="card feature">
+            <div class="icon" aria-hidden="true">◫</div>
+            <h3>One side panel</h3>
+            <p>The local Hermes dashboard stays inside the Chrome side panel. There is no duplicate chat interface to keep in sync.</p>
+          </article>
+        </div>
       </div>
-    </div></section>
+    </section>
 
-    <section class="section" id="security"><div class="wrap security">
-      <article class="card security-copy"><p class="kicker">Local-first security model</p><h2>Authority remains visible and revocable.</h2><ul><li>No Corsen AI relay, analytics, advertising, tracking, or telemetry.</li><li>Loopback-only transport on <code>127.0.0.1:8766</code>.</li><li>Role-bound mutual HMAC authentication without transmitting the pairing secret.</li><li>Explicit tab attachment and fail-closed routing when no valid target exists.</li><li>Sensitive form fields and URL secrets are redacted from browser snapshots.</li><li>Trusted input is disabled by default and shows Chrome's debugger banner when enabled.</li></ul></article>
-      <article class="card diagram" aria-label="Hermes Connector data path"><div class="node">Selected Hermes profile and session</div><div class="arrow">↓</div><div class="node">Hermes Connector companion</div><div class="arrow">↓</div><div class="node">Authenticated loopback broker</div><div class="arrow">↓</div><div class="node">Exact Chrome profile identity</div><div class="arrow">↓</div><div class="node">Explicitly attached tabs only</div></article>
-    </div></section>
-
-    <section class="section" id="requirements"><div class="wrap">
-      <div class="section-head"><p class="kicker">Before pairing</p><h2>What you need.</h2></div>
-      <div class="card requirements"><div class="req"><strong>Browser</strong><span>Google Chrome 120 or later on a supported desktop system.</span></div><div class="req"><strong>Hermes</strong><span>A working local Hermes Agent installation on the same computer.</span></div><div class="req"><strong>Companion</strong><span>Companion 0.2.2, matching the current Store extension exactly.</span></div><div class="req"><strong>Installation</strong><span>Windows uses <code>Install Hermes Connector.cmd</code> or <code>.\install.ps1</code>; macOS and Linux use <code>./install.sh</code>.</span></div></div>
-    </div></section>
-
-    <section class="section"><div class="wrap"><article class="card legacy"><p class="kicker">Legacy versions</p><h2>Still running 0.2.0 or 0.2.1?</h2><p>Do not mix extension and companion versions. The support page retains matching 0.2.0 and 0.2.1 downloads, upgrade instructions, and the required recovery procedure for the known 0.2.0 Chrome LevelDB disk-growth issue.</p><div class="actions"><a class="button" href="support/#compatible-versions">Compatibility table</a><a class="button" href="support/#leveldb-recovery">0.2.0 disk recovery</a></div></article></div></section>
-
-    <section class="section" id="faq"><div class="wrap">
-      <div class="section-head"><p class="kicker">Common questions</p><h2>Hermes Connector FAQ</h2></div>
-      <div class="faq">
-        <details class="card"><summary>Does Chrome update Hermes Connector automatically?</summary><p>Chrome updates the Web Store extension. It cannot update the separately installed local companion, so install the matching companion manually after an extension version change and restart Hermes.</p></details>
-        <details class="card"><summary>Can Hermes control every tab after installation?</summary><p>No. A Hermes session can read or control only normal web tabs you explicitly attach to that exact session. The connector refuses actions when no authorized target exists.</p></details>
-        <details class="card"><summary>Does Corsen AI receive browsing data?</summary><p>No Corsen AI relay or telemetry endpoint is used. Page content goes to the user's local Hermes installation. A remote model provider receives content only when the user configured Hermes to use that provider.</p></details>
-        <details class="card"><summary>What happens when I enable Trusted input?</summary><p>The extension uses Chrome's debugger transport for reliable native input events and dialog handling in the selected attached tab. Chrome displays its debugging banner while it is attached.</p></details>
-        <details class="card"><summary>Is this an official Nous Research extension?</summary><p>No. Hermes Connector is an unofficial community project by Corsen AI and is not affiliated with or endorsed by Nous Research or Google.</p></details>
+    <section class="section" id="security">
+      <div class="wrap security">
+        <div class="card security-copy">
+          <p class="kicker">Local by design</p>
+          <h2>Your tab data does not pass through a Corsen AI relay.</h2>
+          <ul>
+            <li>The companion binds to loopback on your computer.</li>
+            <li>The extension and companion use mutual HMAC authentication.</li>
+            <li>Passwords, one-time codes, and payment-field values are redacted from accessibility snapshots.</li>
+            <li>Tabs stay inaccessible until you attach them to a Hermes session.</li>
+          </ul>
+        </div>
+        <div class="security-note">
+          <h3>Know where your data goes</h3>
+          <p>Selected page content is sent to your local Hermes installation so it can perform the requested action. If you configured Hermes to use a remote model or service, Hermes may then send content to that chosen provider under its terms.</p>
+          <p>Corsen AI does not operate an analytics service, account system, telemetry endpoint, or content relay for the extension.</p>
+          <p><a href="privacy/">Read the complete privacy policy</a> or inspect the <a href="https://github.com/CorsenAI/hermes-connector">public source code</a>.</p>
+        </div>
       </div>
-    </div></section>
+    </section>
+
+    <section class="section" id="requirements">
+      <div class="wrap">
+        <div class="section-head">
+          <p class="kicker">Requirements</p>
+          <h2>What you need before pairing.</h2>
+        </div>
+        <div class="card requirements">
+          <div class="requirements-row"><strong>Browser</strong><span>Google Chrome 120 or later.</span></div>
+          <div class="requirements-row"><strong>Hermes</strong><span>A working local Hermes installation on the same computer.</span></div>
+          <div class="requirements-row"><strong>Companion</strong><span>The Hermes Connector companion with exactly the same version as the extension, installed once for existing profiles and again after creating a new named Hermes profile.</span></div>
+          <div class="requirements-row"><strong>Operating system</strong><span>Windows, macOS, or Linux. Windows uses <code>.\install.ps1</code>; companion 0.2.2 also includes a double-click launcher. macOS and Linux use <code>./install.sh</code>.</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="faq">
+      <div class="wrap faq">
+        <div>
+          <p class="kicker">Questions, answered</p>
+          <h2>Hermes Connector FAQ</h2>
+          <p>For step-by-step installation and troubleshooting, use the <a href="support/">setup and support guide</a>.</p>
+        </div>
+        <div class="faq-list">
+          <details>
+            <summary>What is Hermes Connector?</summary>
+            <p>Hermes Connector is an unofficial Chrome browser extension by Corsen AI. It connects exact local Hermes Agent profiles and sessions to the Chrome tabs selected by the user.</p>
+          </details>
+          <details>
+            <summary>Do I need to install anything besides the Chrome extension?</summary>
+            <p>Yes. Hermes must already run locally, and the matching Hermes Connector companion must be installed once. The companion contains the local broker that securely connects Hermes and Chrome.</p>
+          </details>
+          <details>
+            <summary>Can Hermes access every open tab?</summary>
+            <p>No. Hermes can read or control only tabs you explicitly attach to the selected session. Restricted Chrome pages cannot be controlled.</p>
+          </details>
+          <details>
+            <summary>Does it work with websites where I am already signed in?</summary>
+            <p>Yes. Hermes Connector uses your selected, normal Chrome profile and its existing site sessions. It does not read website cookies or browser login storage directly.</p>
+          </details>
+          <details>
+            <summary>Does Chrome update Hermes Connector automatically?</summary>
+            <p>Chrome updates the Web Store extension automatically. It cannot update the separately installed local companion. After any extension version change, verify the version shown by Chrome, install the companion with exactly the same version, and restart Hermes.</p>
+          </details>
+          <details>
+            <summary>Is this an official Nous Research extension?</summary>
+            <p>No. Hermes Connector is an unofficial community project by Corsen AI and is not affiliated with or endorsed by Nous Research or Google.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section class="wrap card final-cta" aria-labelledby="get-started-title">
+      <p class="kicker">Ready to connect?</p>
+      <h2 id="get-started-title">Put Hermes in the Chrome profile you already use.</h2>
+      <p>Install the extension, run the matching companion once, then choose exactly which Hermes session can use which tab.</p>
+      <div class="actions">
+        <a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Install from Chrome Web Store</a>
+        <a class="button" href="support/">Open the setup guide</a>
+      </div>
+    </section>
   </main>
 
-  <footer><div class="wrap footer-inner"><span>Hermes Connector by Corsen AI · MIT License</span><div class="footer-links"><a href="support/">Setup & support</a><a href="privacy/">Privacy</a><a href="https://github.com/CorsenAI/hermes-connector">Source code</a><a href="mailto:hello@corsen.ai">Contact</a></div></div></footer>
+  <footer>
+    <div class="wrap footer-grid">
+      <div>
+        <strong>Hermes Connector — by Corsen AI</strong>
+        <p class="legal">Unofficial community project. Not affiliated with or endorsed by Nous Research or Google.</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Chrome Web Store</a>
+        <a href="support/">Support</a>
+        <a href="privacy/">Privacy</a>
+        <a href="https://github.com/CorsenAI/hermes-connector">GitHub</a>
+        <a href="mailto:hello@corsen.ai">Contact</a>
+      </div>
+    </div>
+  </footer>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Hermes Connector — Chrome Browser Extension for Hermes Agent</title>
-  <meta name="description" content="Connect Hermes Agent to the Chrome tabs you choose. Use your real signed-in profile with exact session-to-tab routing and a local authenticated companion.">
+  <meta name="description" content="Connect exact local Hermes Agent sessions to only the Chrome tabs you choose, using your real signed-in profile and an authenticated local companion.">
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
   <meta name="theme-color" content="#080c18">
   <link rel="canonical" href="https://corsenai.github.io/hermes-connector/">
@@ -34,17 +34,15 @@
     "alternateName": "Hermes Connector",
     "url": "https://corsenai.github.io/hermes-connector/",
     "installUrl": "https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm",
-    "downloadUrl": "https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip",
+    "downloadUrl": "https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip",
     "applicationCategory": "BrowserApplication",
     "operatingSystem": "Google Chrome 120+ on Windows, macOS, and Linux",
-    "softwareVersion": "0.2.0",
+    "softwareVersion": "0.2.2",
+    "dateModified": "2026-08-12",
     "description": "An unofficial Chrome browser extension that connects exact local Hermes Agent sessions to user-selected tabs in a real signed-in Chrome profile.",
     "image": "https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/store-icon-128.png",
-    "softwareRequirements": "Google Chrome 120 or later, a local Hermes installation, and the Hermes Connector companion",
-    "publisher": {
-      "@type": "Organization",
-      "name": "Corsen AI"
-    },
+    "softwareRequirements": "Google Chrome 120 or later, a local Hermes installation, and the matching Hermes Connector companion",
+    "publisher": {"@type": "Organization", "name": "Corsen AI"},
     "sameAs": [
       "https://github.com/CorsenAI/hermes-connector",
       "https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm"
@@ -59,195 +57,25 @@
   </script>
 
   <style>
-    :root {
-      color-scheme: dark;
-      --bg: #070a13;
-      --surface: #0d1323;
-      --surface-2: #111a31;
-      --line: #253557;
-      --text: #f2f6ff;
-      --muted: #aebbd4;
-      --cyan: #22d3ee;
-      --blue: #4388ff;
-      --violet: #9b5cff;
-      --pink: #f14dc3;
-      --green: #5ee6a8;
-      --shadow: 0 24px 80px rgba(0, 0, 0, .34);
-      --radius: 22px;
-    }
-
-    * { box-sizing: border-box; }
-    html { scroll-behavior: smooth; }
-    body {
-      margin: 0;
-      overflow-x: hidden;
-      background:
-        radial-gradient(850px 520px at 5% 0%, rgba(20, 115, 180, .24), transparent 66%),
-        radial-gradient(780px 480px at 96% 8%, rgba(145, 37, 173, .20), transparent 64%),
-        var(--bg);
-      color: var(--text);
-      font: 16px/1.65 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      -webkit-font-smoothing: antialiased;
-    }
-
-    a { color: #8edcff; }
-    img { display: block; max-width: 100%; }
-    code { padding: .14rem .4rem; border: 1px solid #314268; border-radius: 6px; background: #18223d; color: #f4f7ff; }
-    .wrap { width: min(1160px, calc(100% - 40px)); margin: 0 auto; }
-    .skip-link { position: absolute; left: 16px; top: -100px; z-index: 20; padding: 10px 14px; border-radius: 8px; background: #fff; color: #000; }
-    .skip-link:focus { top: 14px; }
-
-    header {
-      position: sticky;
-      top: 0;
-      z-index: 10;
-      border-bottom: 1px solid rgba(69, 91, 132, .45);
-      background: rgba(7, 10, 19, .82);
-      backdrop-filter: blur(18px);
-    }
-    nav { min-height: 72px; display: flex; align-items: center; justify-content: space-between; gap: 24px; }
-    .brand { display: inline-flex; align-items: center; gap: 11px; color: var(--text); text-decoration: none; font-weight: 800; letter-spacing: -.02em; }
-    .brand img { width: 38px; height: 38px; border-radius: 10px; box-shadow: 0 0 24px rgba(41, 194, 255, .24); }
-    .nav-links { display: flex; align-items: center; gap: 22px; }
-    .nav-links a { color: #c9d4e9; text-decoration: none; font-weight: 650; font-size: 14px; }
-    .nav-links a:hover { color: #fff; }
-
-    .hero { padding: 86px 0 54px; }
-    .hero-grid { display: grid; grid-template-columns: 1.02fr .98fr; align-items: center; gap: clamp(38px, 7vw, 88px); }
-    .eyebrow { display: inline-flex; align-items: center; gap: 9px; margin: 0 0 18px; color: #8ce8fb; font-size: 13px; font-weight: 850; letter-spacing: .13em; text-transform: uppercase; }
-    .eyebrow::before { content: ""; width: 8px; height: 8px; border-radius: 999px; background: var(--green); box-shadow: 0 0 17px var(--green); }
-    h1 { max-width: 790px; margin: 0; font-size: clamp(43px, 6.2vw, 76px); line-height: .98; letter-spacing: -.057em; }
-    .gradient-text { color: transparent; background: linear-gradient(98deg, #51dfff 7%, #6a8cff 45%, #ec65d0 93%); background-clip: text; -webkit-background-clip: text; }
-    .lead { max-width: 670px; margin: 25px 0 0; color: #c5d1e7; font-size: clamp(18px, 2vw, 21px); line-height: 1.55; }
-    .actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 31px; }
-    .button { display: inline-flex; align-items: center; justify-content: center; min-height: 50px; padding: 12px 19px; border: 1px solid #33466f; border-radius: 12px; background: rgba(17, 26, 49, .86); color: var(--text); text-decoration: none; font-weight: 800; transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease; }
-    .button:hover { transform: translateY(-2px); border-color: #6a86b9; }
-    .button:focus-visible, a:focus-visible, summary:focus-visible { outline: 3px solid #77d9ff; outline-offset: 3px; }
-    .button.primary { border-color: transparent; background: linear-gradient(100deg, #287eff, #a94cea 72%, #e647bd); box-shadow: 0 13px 36px rgba(94, 85, 246, .30); }
-    .button.primary:hover { box-shadow: 0 17px 44px rgba(115, 74, 240, .42); }
-    .microcopy { margin-top: 13px; color: var(--muted); font-size: 13px; }
-
-    .card.transition { margin-top: 34px; padding: 27px; border-color: #8d6a2f; background: radial-gradient(500px 230px at 0% 0%, rgba(246, 176, 49, .12), transparent 70%), linear-gradient(155deg, rgba(31, 27, 26, .98), rgba(10, 15, 28, .98)); }
-    .transition h2 { font-size: clamp(25px, 3vw, 34px); }
-    .transition > p { margin: 11px 0; }
-    .transition .warning { color: #ffe0a0; }
-    .compatibility-scroll { overflow-x: auto; margin: 18px 0; }
-    .compatibility { width: 100%; min-width: 760px; border-collapse: collapse; }
-    .compatibility th, .compatibility td { padding: 14px 15px; border: 1px solid #34415c; text-align: left; vertical-align: top; }
-    .compatibility th { background: #18223b; color: #fff; }
-    .compatibility td { color: #d3ddef; }
-    .compatibility td strong { color: #fff; }
-
-    .hero-visual { position: relative; }
-    .hero-visual::before { content: ""; position: absolute; inset: 8% -9% -8% 15%; z-index: -1; border-radius: 50%; background: radial-gradient(circle, rgba(74, 122, 255, .28), rgba(218, 51, 213, .10) 42%, transparent 70%); filter: blur(18px); }
-    .product-frame { overflow: hidden; border: 1px solid #344970; border-radius: 19px; background: #090f1c; box-shadow: var(--shadow); transform: perspective(1300px) rotateY(-3deg) rotateX(1deg); }
-    .product-frame img { width: 100%; height: auto; }
-    .product-frame figcaption { padding: 11px 15px; border-top: 1px solid #253454; color: #9facbf; font-size: 12px; }
-
-    .trust-strip { margin: 44px auto 0; padding: 17px 20px; border: 1px solid rgba(64, 87, 131, .65); border-radius: 15px; background: rgba(13, 19, 35, .72); display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
-    .trust-item { text-align: center; color: #becbe0; font-size: 14px; }
-    .trust-item strong { display: block; color: #fff; font-size: 15px; }
-
-    section { scroll-margin-top: 98px; }
-    .section { padding: 84px 0; }
-    .section-head { max-width: 760px; margin-bottom: 34px; }
-    .kicker { margin: 0 0 7px; color: var(--cyan); font-size: 13px; font-weight: 850; letter-spacing: .12em; text-transform: uppercase; }
-    h2 { margin: 0; font-size: clamp(31px, 4vw, 48px); line-height: 1.08; letter-spacing: -.038em; }
-    .section-head p { margin: 16px 0 0; color: var(--muted); font-size: 18px; }
-    h3 { margin: 0 0 9px; font-size: 20px; letter-spacing: -.02em; }
-    p { color: #cbd6e9; }
-
-    .steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 17px; }
-    .card { border: 1px solid var(--line); border-radius: var(--radius); background: linear-gradient(155deg, rgba(18, 28, 52, .95), rgba(10, 15, 28, .95)); box-shadow: 0 20px 55px rgba(0, 0, 0, .18); }
-    .step { position: relative; min-height: 260px; padding: 27px; overflow: hidden; }
-    .step-number { display: grid; place-items: center; width: 42px; height: 42px; margin-bottom: 39px; border: 1px solid #3c5a8a; border-radius: 12px; background: #142441; color: #92e7fb; font-weight: 900; }
-    .step p { margin-bottom: 0; }
-    .step a { font-weight: 700; }
-    .step::after { content: ""; position: absolute; width: 150px; height: 150px; right: -68px; bottom: -85px; border-radius: 50%; background: var(--glow, rgba(53, 208, 255, .14)); filter: blur(8px); }
-
-    .feature-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
-    .feature { min-height: 190px; padding: 27px; }
-    .icon { display: inline-grid; place-items: center; width: 38px; height: 38px; margin-bottom: 22px; border-radius: 11px; background: linear-gradient(145deg, rgba(58, 160, 255, .22), rgba(198, 67, 226, .19)); color: #a2e7ff; font-weight: 900; }
-    .feature p { margin-bottom: 0; }
-
-    .security { display: grid; grid-template-columns: .9fr 1.1fr; gap: 28px; align-items: stretch; }
-    .security-copy { padding: 34px; }
-    .security-copy h2 { font-size: clamp(30px, 4vw, 44px); }
-    .security-copy ul { margin: 25px 0 0; padding: 0; list-style: none; }
-    .security-copy li { position: relative; margin: 13px 0; padding-left: 28px; color: #cfdaed; }
-    .security-copy li::before { content: "✓"; position: absolute; left: 0; color: var(--green); font-weight: 900; }
-    .security-note { padding: 31px; border: 1px solid #384775; border-radius: var(--radius); background: radial-gradient(420px 220px at 90% 0%, rgba(171, 70, 219, .18), transparent 70%), #10172a; }
-    .security-note p:last-child { margin-bottom: 0; }
-
-    .requirements { overflow: hidden; }
-    .requirements-row { display: grid; grid-template-columns: 180px 1fr; gap: 26px; padding: 21px 26px; border-bottom: 1px solid #263653; }
-    .requirements-row:last-child { border-bottom: 0; }
-    .requirements-row strong { color: #fff; }
-    .requirements-row span { color: #c8d4e8; }
-
-    .faq { display: grid; grid-template-columns: .7fr 1.3fr; gap: 46px; align-items: start; }
-    .faq-list { display: grid; gap: 12px; }
-    details { border: 1px solid var(--line); border-radius: 15px; background: rgba(15, 23, 42, .78); }
-    summary { cursor: pointer; padding: 19px 21px; color: #f4f7ff; font-weight: 800; }
-    details p { margin: 0; padding: 0 21px 20px; }
-
-    .final-cta { padding: 48px; text-align: center; background: radial-gradient(520px 240px at 50% 0%, rgba(53, 151, 255, .23), transparent 70%), linear-gradient(145deg, #111a32, #0c1221); }
-    .final-cta p { max-width: 690px; margin: 14px auto 0; color: #bdc9df; font-size: 18px; }
-    .final-cta .actions { justify-content: center; }
-
-    footer { margin-top: 88px; border-top: 1px solid #202d48; padding: 31px 0 42px; color: var(--muted); font-size: 14px; }
-    .footer-grid { display: flex; justify-content: space-between; gap: 30px; align-items: flex-start; }
-    .footer-links { display: flex; flex-wrap: wrap; gap: 17px; }
-    footer a { color: #c5d4ea; }
-    .legal { max-width: 640px; margin: 12px 0 0; color: #8f9db5; font-size: 13px; }
-
-    @media (max-width: 900px) {
-      .hero-grid, .security, .faq { grid-template-columns: 1fr; }
-      .hero-visual { max-width: 740px; }
-      .product-frame { transform: none; }
-      .steps { grid-template-columns: 1fr; }
-      .step { min-height: auto; }
-      .step-number { margin-bottom: 24px; }
-      .trust-strip { grid-template-columns: repeat(2, 1fr); }
-      .faq { gap: 25px; }
-    }
-
-    @media (max-width: 640px) {
-      .wrap { width: min(100% - 28px, 1160px); }
-      .nav-links a:not(.nav-cta) { display: none; }
-      .hero { padding-top: 58px; }
-      h1 { font-size: clamp(42px, 14vw, 58px); }
-      .feature-grid, .trust-strip { grid-template-columns: 1fr; }
-      .trust-item { text-align: left; }
-      .section { padding: 65px 0; }
-      .security-copy, .security-note, .final-cta { padding: 26px; }
-      .requirements-row { grid-template-columns: 1fr; gap: 5px; }
-      .footer-grid { flex-direction: column; }
-      .button { width: 100%; }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      html { scroll-behavior: auto; }
-      *, *::before, *::after { transition-duration: .01ms !important; }
-    }
+    :root{color-scheme:dark;--bg:#070a13;--surface:#0d1323;--surface2:#111a31;--line:#253557;--text:#f2f6ff;--muted:#aebbd4;--cyan:#22d3ee;--blue:#4388ff;--violet:#9b5cff;--pink:#f14dc3;--green:#5ee6a8;--warn:#ffd782;--shadow:0 24px 80px rgba(0,0,0,.34);--radius:22px}
+    *{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;overflow-x:hidden;background:radial-gradient(850px 520px at 5% 0%,rgba(20,115,180,.24),transparent 66%),radial-gradient(780px 480px at 96% 8%,rgba(145,37,173,.20),transparent 64%),var(--bg);color:var(--text);font:16px/1.65 Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}
+    a{color:#8edcff}img{display:block;max-width:100%}code{padding:.14rem .4rem;border:1px solid #314268;border-radius:6px;background:#18223d;color:#f4f7ff}.wrap{width:min(1160px,calc(100% - 40px));margin:0 auto}.skip-link{position:absolute;left:16px;top:-100px;z-index:20;padding:10px 14px;border-radius:8px;background:#fff;color:#000}.skip-link:focus{top:14px}
+    header{position:sticky;top:0;z-index:10;border-bottom:1px solid rgba(69,91,132,.45);background:rgba(7,10,19,.82);backdrop-filter:blur(18px)}nav{min-height:72px;display:flex;align-items:center;justify-content:space-between;gap:24px}.brand{display:inline-flex;align-items:center;gap:11px;color:var(--text);text-decoration:none;font-weight:800;letter-spacing:-.02em}.brand img{width:38px;height:38px;border-radius:10px;box-shadow:0 0 24px rgba(41,194,255,.24)}.nav-links{display:flex;align-items:center;gap:22px}.nav-links a{color:#c9d4e9;text-decoration:none;font-weight:650;font-size:14px}.nav-links a:hover{color:#fff}
+    .hero{padding:86px 0 54px}.hero-grid{display:grid;grid-template-columns:1.02fr .98fr;align-items:center;gap:clamp(38px,7vw,88px)}.eyebrow,.kicker{margin:0 0 12px;color:#8ce8fb;font-size:13px;font-weight:850;letter-spacing:.13em;text-transform:uppercase}.eyebrow{display:inline-flex;align-items:center;gap:9px}.eyebrow:before{content:"";width:8px;height:8px;border-radius:999px;background:var(--green);box-shadow:0 0 17px var(--green)}h1{max-width:790px;margin:0;font-size:clamp(43px,6.2vw,76px);line-height:.98;letter-spacing:-.057em}.gradient-text{color:transparent;background:linear-gradient(98deg,#51dfff 7%,#6a8cff 45%,#ec65d0 93%);background-clip:text;-webkit-background-clip:text}.lead{max-width:670px;margin:25px 0 0;color:#c5d1e7;font-size:clamp(18px,2vw,21px);line-height:1.55}.actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:31px}.button{display:inline-flex;align-items:center;justify-content:center;min-height:50px;padding:12px 19px;border:1px solid #33466f;border-radius:12px;background:rgba(17,26,49,.86);color:var(--text);text-decoration:none;font-weight:800;transition:transform .18s ease,border-color .18s ease,box-shadow .18s ease}.button:hover{transform:translateY(-2px);border-color:#6a86b9}.button:focus-visible,a:focus-visible,summary:focus-visible{outline:3px solid #77d9ff;outline-offset:3px}.button.primary{border-color:transparent;background:linear-gradient(100deg,#287eff,#a94cea 72%,#e647bd);box-shadow:0 13px 36px rgba(94,85,246,.30)}.microcopy{margin-top:13px;color:var(--muted);font-size:13px}
+    .product-frame{overflow:hidden;border:1px solid #344970;border-radius:19px;background:#090f1c;box-shadow:var(--shadow);transform:perspective(1300px) rotateY(-3deg) rotateX(1deg)}.product-frame figcaption{padding:11px 15px;border-top:1px solid #253454;color:#9facbf;font-size:12px}
+    .release-card{margin-top:36px;padding:27px;border:1px solid #337760;border-radius:var(--radius);background:radial-gradient(500px 230px at 0 0,rgba(61,226,173,.12),transparent 70%),linear-gradient(155deg,rgba(15,42,38,.98),rgba(10,15,28,.98));display:grid;grid-template-columns:1fr auto;gap:24px;align-items:center}.release-card h2{font-size:clamp(25px,3vw,34px)}.release-card p{margin:8px 0 0}.release-facts{display:grid;grid-template-columns:repeat(3,auto);gap:10px}.pill{padding:8px 11px;border:1px solid #376f62;border-radius:999px;color:#c9f7e5;background:rgba(14,51,43,.7);font-size:13px;font-weight:750;white-space:nowrap}
+    .trust-strip{margin:34px auto 0;padding:17px 20px;border:1px solid rgba(64,87,131,.65);border-radius:15px;background:rgba(13,19,35,.72);display:grid;grid-template-columns:repeat(4,1fr);gap:18px}.trust-item{text-align:center;color:#becbe0;font-size:14px}.trust-item strong{display:block;color:#fff;font-size:15px}
+    section{scroll-margin-top:98px}.section{padding:84px 0}.section-head{max-width:780px;margin-bottom:34px}.section-head h2{margin:0;font-size:clamp(31px,4vw,48px);line-height:1.08;letter-spacing:-.038em}.section-head p{margin:16px 0 0;color:var(--muted);font-size:18px}.card{border:1px solid var(--line);border-radius:var(--radius);background:linear-gradient(155deg,rgba(18,28,52,.95),rgba(10,15,28,.95));box-shadow:0 20px 55px rgba(0,0,0,.18)}.steps{display:grid;grid-template-columns:repeat(3,1fr);gap:17px}.step{position:relative;min-height:260px;padding:27px;overflow:hidden}.step-number{display:grid;place-items:center;width:42px;height:42px;margin-bottom:39px;border:1px solid #3c5a8a;border-radius:12px;background:#142441;color:#92e7fb;font-weight:900}.step h3,.feature h3{margin:0 0 9px;font-size:20px}.step p,.feature p{margin-bottom:0;color:#cbd6e9}.feature-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:18px}.feature{min-height:190px;padding:27px}.icon{display:inline-grid;place-items:center;width:38px;height:38px;margin-bottom:22px;border-radius:11px;background:linear-gradient(145deg,rgba(58,160,255,.22),rgba(198,67,226,.19));color:#a2e7ff;font-weight:900}
+    .security{display:grid;grid-template-columns:.9fr 1.1fr;gap:28px;align-items:stretch}.security-copy{padding:34px}.security-copy h2{font-size:clamp(30px,4vw,44px);line-height:1.1;margin:0}.security-copy ul{margin:25px 0 0;padding:0;list-style:none}.security-copy li{position:relative;margin:13px 0;padding-left:28px;color:#cfdaed}.security-copy li:before{content:"✓";position:absolute;left:0;color:var(--green);font-weight:900}.diagram{padding:30px;display:grid;align-content:center;gap:12px}.node{padding:14px 16px;border:1px solid #31476f;border-radius:12px;background:#111d35;color:#e8effd;font-weight:700}.arrow{text-align:center;color:#73d8ef;font-size:20px}.requirements{overflow:hidden}.req{display:grid;grid-template-columns:180px 1fr;gap:22px;padding:18px 23px;border-top:1px solid var(--line)}.req:first-child{border-top:0}.req strong{color:#fff}.req span{color:#c7d2e6}.faq{display:grid;gap:12px}.faq details{padding:19px 21px}.faq summary{cursor:pointer;font-weight:800}.faq p{margin:12px 0 0;color:#cbd6e9}.legacy{padding:26px;border-color:#715c31}.legacy .warning{color:var(--warn)}footer{padding:30px 0 48px;border-top:1px solid rgba(64,87,131,.55);color:#9facbf}.footer-inner{display:flex;justify-content:space-between;gap:24px;flex-wrap:wrap}.footer-links{display:flex;gap:16px;flex-wrap:wrap}
+    @media(max-width:900px){.hero-grid,.security{grid-template-columns:1fr}.product-frame{transform:none}.release-card{grid-template-columns:1fr}.release-facts{grid-template-columns:repeat(3,1fr)}.steps{grid-template-columns:1fr}.trust-strip{grid-template-columns:repeat(2,1fr)}}@media(max-width:650px){.wrap{width:min(100% - 28px,1160px)}.nav-links>a:not(.nav-cta){display:none}.hero{padding-top:58px}.feature-grid{grid-template-columns:1fr}.release-facts{grid-template-columns:1fr}.trust-strip{grid-template-columns:1fr}.req{grid-template-columns:1fr;gap:4px}}
   </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
-  <header>
-    <nav class="wrap" aria-label="Primary navigation">
-      <a class="brand" href="./" aria-label="Hermes Connector home">
-        <img src="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/store-icon-128.png" width="38" height="38" alt="">
-        <span>Hermes Connector</span>
-      </a>
-      <div class="nav-links">
-        <a href="#how-it-works">How it works</a>
-        <a href="#security">Security</a>
-        <a href="#faq">FAQ</a>
-        <a class="button nav-cta" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Install for Chrome</a>
-      </div>
-    </nav>
-  </header>
+  <header><nav class="wrap" aria-label="Primary navigation">
+    <a class="brand" href="./" aria-label="Hermes Connector home"><img src="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/store-icon-128.png" width="38" height="38" alt=""><span>Hermes Connector</span></a>
+    <div class="nav-links"><a href="#how-it-works">How it works</a><a href="#security">Security</a><a href="#faq">FAQ</a><a class="button nav-cta" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Install for Chrome</a></div>
+  </nav></header>
 
   <main id="main">
     <section class="hero">
@@ -256,197 +84,63 @@
           <p class="eyebrow">Chrome browser extension for Hermes Agent</p>
           <h1>Your Hermes session. <span class="gradient-text">Your chosen tabs.</span></h1>
           <p class="lead">Hermes Connector links exact local Hermes Agent sessions to only the Chrome tabs you attach—inside the signed-in browser profile you already use.</p>
-          <div class="actions">
-            <a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add to Chrome</a>
-            <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip">Download companion 0.2.0</a>
-          </div>
-          <p class="microcopy">Public Store version: 0.2.0 · Install the companion with the exact same version</p>
+          <div class="actions"><a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add version 0.2.2 to Chrome</a><a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a></div>
+          <p class="microcopy">Current public pair: extension 0.2.2 + companion 0.2.2 · Windows, macOS, and Linux</p>
         </div>
-
-        <figure class="product-frame hero-visual">
-          <img src="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/screenshot-product-1280x800.png" width="1280" height="800" alt="Hermes Connector side panel attached to the Project Atlas tab in Chrome" fetchpriority="high">
-          <figcaption>Hermes Connector routes the selected Hermes session to its explicitly attached tab.</figcaption>
-        </figure>
+        <figure class="product-frame"><img src="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/screenshot-product-1280x800.png" width="1280" height="800" alt="Hermes Connector side panel attached to a selected Chrome tab" fetchpriority="high"><figcaption>Each Hermes session can act only on tabs explicitly attached to it.</figcaption></figure>
       </div>
 
-      <div class="wrap card transition" role="note" aria-labelledby="version-match-title">
-        <p class="kicker">Store update in review</p>
-        <h2 id="version-match-title">Match the companion to the extension version shown by Chrome.</h2>
-        <p>Open <code>chrome://extensions</code> and check Hermes Connector before downloading the local companion.</p>
-        <div class="compatibility-scroll"><table class="compatibility">
-          <thead><tr><th>Extension installed in Chrome</th><th>Compatible local companion</th><th>Use this pair when</th></tr></thead>
-          <tbody>
-            <tr><td><strong>0.2.0</strong> from the <a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">public Chrome Web Store listing</a></td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip">Download companion 0.2.0</a></td><td>Chrome currently shows extension version 0.2.0.</td></tr>
-            <tr><td><strong>0.2.2</strong> Store candidate/reviewer build</td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a></td><td>Google review or Chrome already shows extension version 0.2.2.</td></tr>
-          </tbody>
-        </table></div>
-        <p class="warning"><strong>Do not mix versions:</strong> 0.2.0 works with 0.2.0; 0.2.2 works with 0.2.2. Do not install companion 0.2.2 until Chrome itself shows extension 0.2.2. See the <a href="support/#compatible-versions">versioned setup guide</a>.</p>
+      <div class="wrap release-card" role="note" aria-labelledby="release-title">
+        <div><p class="kicker">Current Chrome Web Store release</p><h2 id="release-title">Version 0.2.2 is public. Keep the extension and companion matched.</h2><p>Chrome updates the Store extension, but it cannot update the separately installed local companion. Install companion 0.2.2 once and restart Hermes.</p></div>
+        <div class="release-facts" aria-label="Release details"><span class="pill">Version 0.2.2</span><span class="pill">Protocol 4</span><span class="pill">Port 8766</span></div>
       </div>
 
-      <div class="wrap trust-strip" role="list" aria-label="Product summary">
-        <div class="trust-item" role="listitem"><strong>Exact routing</strong>Session → chosen tab</div>
-        <div class="trust-item" role="listitem"><strong>Real Chrome profile</strong>Keep existing site sessions</div>
-        <div class="trust-item" role="listitem"><strong>Local connection</strong>Authenticated loopback</div>
-        <div class="trust-item" role="listitem"><strong>Fail closed</strong>No silent fallback tab</div>
-      </div>
+      <div class="wrap trust-strip" role="list" aria-label="Product summary"><div class="trust-item" role="listitem"><strong>Exact routing</strong>Session → chosen tab</div><div class="trust-item" role="listitem"><strong>Real Chrome profile</strong>Keep existing site sessions</div><div class="trust-item" role="listitem"><strong>Local connection</strong>Authenticated loopback</div><div class="trust-item" role="listitem"><strong>Fail closed</strong>No silent fallback tab</div></div>
     </section>
 
-    <section class="section" id="how-it-works">
-      <div class="wrap">
-        <div class="section-head">
-          <p class="kicker">Start in three steps</p>
-          <h2>Connect Chrome to Hermes without creating another browser.</h2>
-          <p>The side panel embeds your local Hermes dashboard. You keep your real Chrome profile, choose the Hermes session, and decide which tabs it may use.</p>
-        </div>
-        <div class="steps">
-          <article class="card step" style="--glow:rgba(42,211,238,.18)">
-            <div class="step-number">1</div>
-            <h3>Install the extension</h3>
-            <p><a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add Hermes Connector from the Chrome Web Store</a>, then open its side panel.</p>
-          </article>
-          <article class="card step" style="--glow:rgba(100,107,255,.20)">
-            <div class="step-number">2</div>
-            <h3>Install the local companion</h3>
-            <p>Check the extension version, download the exact matching companion from the table above, run its installer once, and restart Hermes.</p>
-          </article>
-          <article class="card step" style="--glow:rgba(234,70,199,.18)">
-            <div class="step-number">3</div>
-            <h3>Pair, select, attach</h3>
-            <p>Paste the locally printed pairing code, select a real Hermes session, then attach only the tabs that session may read or control.</p>
-          </article>
-        </div>
+    <section class="section" id="how-it-works"><div class="wrap">
+      <div class="section-head"><p class="kicker">Start in three steps</p><h2>Connect Chrome to Hermes without creating another browser.</h2><p>The side panel embeds your local Hermes dashboard. You keep your real Chrome profile, select the Hermes session, and decide which tabs it may use.</p></div>
+      <div class="steps">
+        <article class="card step"><div class="step-number">1</div><h3>Install the extension</h3><p><a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add Hermes Connector 0.2.2 from the Chrome Web Store</a>, then open its side panel.</p></article>
+        <article class="card step"><div class="step-number">2</div><h3>Install the local companion</h3><p>Download companion 0.2.2, run the installer once, and restart every running Hermes dashboard, gateway, or chat process.</p></article>
+        <article class="card step"><div class="step-number">3</div><h3>Pair, select, attach</h3><p>Paste the locally printed pairing code, select a real Hermes session, then attach only the tabs that session may read or control.</p></article>
       </div>
-    </section>
+    </div></section>
 
-    <section class="section" id="features">
-      <div class="wrap">
-        <div class="section-head">
-          <p class="kicker">Built for real workflows</p>
-          <h2>Browser control with an explicit boundary.</h2>
-          <p>Run simultaneous projects without accidentally sending one Hermes session into another project's browser context.</p>
-        </div>
-        <div class="feature-grid">
-          <article class="card feature">
-            <div class="icon" aria-hidden="true">↗</div>
-            <h3>Exact session-to-tab scope</h3>
-            <p>Attach one or more Chrome tabs to a specific Hermes profile and session. An unbound session is rejected instead of falling back to another tab.</p>
-          </article>
-          <article class="card feature">
-            <div class="icon" aria-hidden="true">◎</div>
-            <h3>Your signed-in browser</h3>
-            <p>Hermes works with the Chrome profile and site sessions you already use. Hermes Connector does not launch a hidden automation profile.</p>
-          </article>
-          <article class="card feature">
-            <div class="icon" aria-hidden="true">⌁</div>
-            <h3>Useful browser actions</h3>
-            <p>Navigate, inspect, read, click, type, scroll, take requested screenshots, use keys, select options, drag, search, and manage scoped tabs.</p>
-          </article>
-          <article class="card feature">
-            <div class="icon" aria-hidden="true">◫</div>
-            <h3>One side panel</h3>
-            <p>The local Hermes dashboard stays inside the Chrome side panel. There is no duplicate chat interface to keep in sync.</p>
-          </article>
-        </div>
+    <section class="section" id="features"><div class="wrap">
+      <div class="section-head"><p class="kicker">Built for real workflows</p><h2>Browser control with an explicit boundary.</h2><p>Hermes receives the browser capabilities it needs without being granted every open tab indiscriminately.</p></div>
+      <div class="feature-grid">
+        <article class="card feature"><span class="icon">01</span><h3>Exact session-to-tab routing</h3><p>Every browser request returns to the selected Hermes profile, session, Chrome profile, and attached target.</p></article>
+        <article class="card feature"><span class="icon">02</span><h3>Normal signed-in Chrome</h3><p>Use existing website sessions in the Chrome profile you already operate instead of a hidden automation browser.</p></article>
+        <article class="card feature"><span class="icon">03</span><h3>Scoped browser actions</h3><p>Navigate, inspect, read, click, type, scroll, hover, select, drag, use keys, take screenshots, search pages, and manage authorized tabs.</p></article>
+        <article class="card feature"><span class="icon">04</span><h3>Concurrent project isolation</h3><p>Separate Hermes sessions and Chrome profiles can work at the same time without inheriting one another's tab scope.</p></article>
       </div>
-    </section>
+    </div></section>
 
-    <section class="section" id="security">
-      <div class="wrap security">
-        <div class="card security-copy">
-          <p class="kicker">Local by design</p>
-          <h2>Your tab data does not pass through a Corsen AI relay.</h2>
-          <ul>
-            <li>The companion binds to loopback on your computer.</li>
-            <li>The extension and companion use mutual HMAC authentication.</li>
-            <li>Passwords, one-time codes, and payment-field values are redacted from accessibility snapshots.</li>
-            <li>Tabs stay inaccessible until you attach them to a Hermes session.</li>
-          </ul>
-        </div>
-        <div class="security-note">
-          <h3>Know where your data goes</h3>
-          <p>Selected page content is sent to your local Hermes installation so it can perform the requested action. If you configured Hermes to use a remote model or service, Hermes may then send content to that chosen provider under its terms.</p>
-          <p>Corsen AI does not operate an analytics service, account system, telemetry endpoint, or content relay for the extension.</p>
-          <p><a href="privacy/">Read the complete privacy policy</a> or inspect the <a href="https://github.com/CorsenAI/hermes-connector">public source code</a>.</p>
-        </div>
-      </div>
-    </section>
+    <section class="section" id="security"><div class="wrap security">
+      <article class="card security-copy"><p class="kicker">Local-first security model</p><h2>Authority remains visible and revocable.</h2><ul><li>No Corsen AI relay, analytics, advertising, tracking, or telemetry.</li><li>Loopback-only transport on <code>127.0.0.1:8766</code>.</li><li>Role-bound mutual HMAC authentication without transmitting the pairing secret.</li><li>Explicit tab attachment and fail-closed routing when no valid target exists.</li><li>Sensitive form fields and URL secrets are redacted from browser snapshots.</li><li>Trusted input is disabled by default and shows Chrome's debugger banner when enabled.</li></ul></article>
+      <article class="card diagram" aria-label="Hermes Connector data path"><div class="node">Selected Hermes profile and session</div><div class="arrow">↓</div><div class="node">Hermes Connector companion</div><div class="arrow">↓</div><div class="node">Authenticated loopback broker</div><div class="arrow">↓</div><div class="node">Exact Chrome profile identity</div><div class="arrow">↓</div><div class="node">Explicitly attached tabs only</div></article>
+    </div></section>
 
-    <section class="section" id="requirements">
-      <div class="wrap">
-        <div class="section-head">
-          <p class="kicker">Requirements</p>
-          <h2>What you need before pairing.</h2>
-        </div>
-        <div class="card requirements">
-          <div class="requirements-row"><strong>Browser</strong><span>Google Chrome 120 or later.</span></div>
-          <div class="requirements-row"><strong>Hermes</strong><span>A working local Hermes installation on the same computer.</span></div>
-          <div class="requirements-row"><strong>Companion</strong><span>The Hermes Connector companion with exactly the same version as the extension, installed once for existing profiles and again after creating a new named Hermes profile.</span></div>
-          <div class="requirements-row"><strong>Operating system</strong><span>Windows, macOS, or Linux. Windows uses <code>.\install.ps1</code>; companion 0.2.2 also includes a double-click launcher. macOS and Linux use <code>./install.sh</code>.</span></div>
-        </div>
-      </div>
-    </section>
+    <section class="section" id="requirements"><div class="wrap">
+      <div class="section-head"><p class="kicker">Before pairing</p><h2>What you need.</h2></div>
+      <div class="card requirements"><div class="req"><strong>Browser</strong><span>Google Chrome 120 or later on a supported desktop system.</span></div><div class="req"><strong>Hermes</strong><span>A working local Hermes Agent installation on the same computer.</span></div><div class="req"><strong>Companion</strong><span>Companion 0.2.2, matching the current Store extension exactly.</span></div><div class="req"><strong>Installation</strong><span>Windows uses <code>Install Hermes Connector.cmd</code> or <code>.\install.ps1</code>; macOS and Linux use <code>./install.sh</code>.</span></div></div>
+    </div></section>
 
-    <section class="section" id="faq">
-      <div class="wrap faq">
-        <div>
-          <p class="kicker">Questions, answered</p>
-          <h2>Hermes Connector FAQ</h2>
-          <p>For step-by-step installation and troubleshooting, use the <a href="support/">setup and support guide</a>.</p>
-        </div>
-        <div class="faq-list">
-          <details>
-            <summary>What is Hermes Connector?</summary>
-            <p>Hermes Connector is an unofficial Chrome browser extension by Corsen AI. It connects exact local Hermes Agent profiles and sessions to the Chrome tabs selected by the user.</p>
-          </details>
-          <details>
-            <summary>Do I need to install anything besides the Chrome extension?</summary>
-            <p>Yes. Hermes must already run locally, and the Hermes Connector companion must be installed once. The companion contains the local broker that securely connects Hermes and Chrome.</p>
-          </details>
-          <details>
-            <summary>Can Hermes access every open tab?</summary>
-            <p>No. Hermes can read or control only tabs you explicitly attach to the selected session. Restricted Chrome pages cannot be controlled.</p>
-          </details>
-          <details>
-            <summary>Does it work with websites where I am already signed in?</summary>
-            <p>Yes. Hermes Connector uses your selected, normal Chrome profile and its existing site sessions. It does not read website cookies or browser login storage directly.</p>
-          </details>
-          <details>
-            <summary>Does Chrome update Hermes Connector automatically?</summary>
-            <p>Chrome updates the Web Store extension automatically after Google publishes an approved update. It cannot update the separately installed local companion. When Chrome changes the extension from 0.2.0 to 0.2.2, manually install companion 0.2.2 and restart Hermes; never upgrade the companion before the extension.</p>
-          </details>
-          <details>
-            <summary>Is this an official Nous Research extension?</summary>
-            <p>No. Hermes Connector is an unofficial community project by Corsen AI and is not affiliated with or endorsed by Nous Research or Google.</p>
-          </details>
-        </div>
-      </div>
-    </section>
+    <section class="section"><div class="wrap"><article class="card legacy"><p class="kicker">Legacy versions</p><h2>Still running 0.2.0 or 0.2.1?</h2><p>Do not mix extension and companion versions. The support page retains matching 0.2.0 and 0.2.1 downloads, upgrade instructions, and the required recovery procedure for the known 0.2.0 Chrome LevelDB disk-growth issue.</p><div class="actions"><a class="button" href="support/#compatible-versions">Compatibility table</a><a class="button" href="support/#leveldb-recovery">0.2.0 disk recovery</a></div></article></div></section>
 
-    <section class="wrap card final-cta" aria-labelledby="get-started-title">
-      <p class="kicker">Ready to connect?</p>
-      <h2 id="get-started-title">Put Hermes in the Chrome profile you already use.</h2>
-      <p>Install the extension, run the companion once, then choose exactly which Hermes session can use which tab.</p>
-      <div class="actions">
-        <a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Install from Chrome Web Store</a>
-        <a class="button" href="support/">Open the setup guide</a>
+    <section class="section" id="faq"><div class="wrap">
+      <div class="section-head"><p class="kicker">Common questions</p><h2>Hermes Connector FAQ</h2></div>
+      <div class="faq">
+        <details class="card"><summary>Does Chrome update Hermes Connector automatically?</summary><p>Chrome updates the Web Store extension. It cannot update the separately installed local companion, so install the matching companion manually after an extension version change and restart Hermes.</p></details>
+        <details class="card"><summary>Can Hermes control every tab after installation?</summary><p>No. A Hermes session can read or control only normal web tabs you explicitly attach to that exact session. The connector refuses actions when no authorized target exists.</p></details>
+        <details class="card"><summary>Does Corsen AI receive browsing data?</summary><p>No Corsen AI relay or telemetry endpoint is used. Page content goes to the user's local Hermes installation. A remote model provider receives content only when the user configured Hermes to use that provider.</p></details>
+        <details class="card"><summary>What happens when I enable Trusted input?</summary><p>The extension uses Chrome's debugger transport for reliable native input events and dialog handling in the selected attached tab. Chrome displays its debugging banner while it is attached.</p></details>
+        <details class="card"><summary>Is this an official Nous Research extension?</summary><p>No. Hermes Connector is an unofficial community project by Corsen AI and is not affiliated with or endorsed by Nous Research or Google.</p></details>
       </div>
-    </section>
+    </div></section>
   </main>
 
-  <footer>
-    <div class="wrap footer-grid">
-      <div>
-        <strong>Hermes Connector — by Corsen AI</strong>
-        <p class="legal">Unofficial community project. Not affiliated with or endorsed by Nous Research or Google.</p>
-      </div>
-      <div class="footer-links">
-        <a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Chrome Web Store</a>
-        <a href="support/">Support</a>
-        <a href="privacy/">Privacy</a>
-        <a href="https://github.com/CorsenAI/hermes-connector">GitHub</a>
-        <a href="mailto:hello@corsen.ai">Contact</a>
-      </div>
-    </div>
-  </footer>
+  <footer><div class="wrap footer-inner"><span>Hermes Connector by Corsen AI · MIT License</span><div class="footer-links"><a href="support/">Setup & support</a><a href="privacy/">Privacy</a><a href="https://github.com/CorsenAI/hermes-connector">Source code</a><a href="mailto:hello@corsen.ai">Contact</a></div></div></footer>
 </body>
 </html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://corsenai.github.io/hermes-connector/</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-08-12</lastmod>
   </url>
   <url>
     <loc>https://corsenai.github.io/hermes-connector/support/</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-08-12</lastmod>
   </url>
   <url>
     <loc>https://corsenai.github.io/hermes-connector/privacy/</loc>

--- a/docs/support/index.html
+++ b/docs/support/index.html
@@ -1,58 +1,125 @@
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="Install, pair, upgrade, and troubleshoot Hermes Connector, the Chrome browser extension and local companion for Hermes Agent.">
-<meta name="robots" content="index,follow,max-image-preview:large">
-<link rel="canonical" href="https://corsenai.github.io/hermes-connector/support/">
-<meta property="og:type" content="website">
-<meta property="og:title" content="Setup & Support — Hermes Connector">
-<meta property="og:description" content="Install, pair, upgrade, and troubleshoot the Hermes Connector Chrome extension and local companion.">
-<meta property="og:url" content="https://corsenai.github.io/hermes-connector/support/">
-<meta property="og:image" content="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/promo-marquee-1400x560.png">
-<meta property="og:image:alt" content="Hermes Connector — Local AI. Your tabs. By Corsen AI.">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Setup &amp; Support — Hermes Connector">
-<meta name="twitter:description" content="Install, pair, upgrade, and troubleshoot the Hermes Connector Chrome extension and local companion.">
-<meta name="twitter:image" content="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/promo-marquee-1400x560.png">
-<title>Setup &amp; Support — Hermes Connector for Hermes Agent</title>
-<style>
-  :root{--bg:#090d19;--card:#11182b;--bd:#29375f;--tx:#edf2ff;--mut:#aeb9d2;--acc:#79cfff;--warn:#ffd782}*{box-sizing:border-box}body{margin:0;background:radial-gradient(900px 500px at 80% -10%,#281442 0%,var(--bg) 62%);color:var(--tx);font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:52px 20px}main{max-width:900px;margin:auto}h1{font-size:38px;margin:0 0 8px}.sub{color:var(--mut);margin:0 0 28px}.card{background:var(--card);border:1px solid var(--bd);border-radius:16px;padding:25px 29px;margin:0 0 17px}.transition{border-color:#8e6a2b;background:linear-gradient(145deg,#221b16,var(--card) 62%)}h2{font-size:20px;margin:0 0 10px}h3{font-size:17px;margin:22px 0 8px}li,p{color:#d9e1f2}code{background:#192341;border:1px solid var(--bd);border-radius:6px;padding:2px 6px}a{color:var(--acc)}nav{margin-top:24px;color:var(--mut)}.warning{color:var(--warn)}.table-wrap{overflow-x:auto;margin:18px 0}table{width:100%;min-width:690px;border-collapse:collapse}th,td{padding:13px 14px;border:1px solid var(--bd);text-align:left;vertical-align:top}th{background:#18223b;color:#fff}td{color:#d9e1f2}td strong{color:#fff}.pair{white-space:nowrap}@media(max-width:600px){body{padding:34px 14px}.card{padding:21px 19px}h1{font-size:32px}}
-</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Install, pair, upgrade, and troubleshoot Hermes Connector, including exact extension and companion version compatibility.">
+  <meta name="robots" content="index,follow,max-image-preview:large">
+  <meta name="theme-color" content="#090d19">
+  <link rel="canonical" href="https://corsenai.github.io/hermes-connector/support/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Setup & Support — Hermes Connector">
+  <meta property="og:description" content="Install, pair, upgrade, and troubleshoot the Hermes Connector Chrome extension and local companion.">
+  <meta property="og:url" content="https://corsenai.github.io/hermes-connector/support/">
+  <meta property="og:image" content="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/promo-marquee-1400x560.png">
+  <meta property="og:image:alt" content="Hermes Connector — Local AI. Your tabs. By Corsen AI.">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Setup & Support — Hermes Connector">
+  <meta name="twitter:description" content="Install, pair, upgrade, and troubleshoot the Hermes Connector Chrome extension and local companion.">
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/promo-marquee-1400x560.png">
+  <title>Setup &amp; Support — Hermes Connector for Hermes Agent</title>
+  <style>
+    :root{color-scheme:dark;--bg:#090d19;--card:#11182b;--card2:#151e35;--bd:#2a395f;--tx:#edf2ff;--mut:#aeb9d2;--acc:#79cfff;--good:#71e5ac;--warn:#ffd782;--danger:#ff9ca9}
+    *{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;background:radial-gradient(900px 500px at 80% -10%,#281442 0%,var(--bg) 62%);color:var(--tx);font:16px/1.65 Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:52px 20px}
+    main{max-width:960px;margin:auto}h1{font-size:clamp(34px,6vw,46px);line-height:1.08;margin:0 0 8px;letter-spacing:-.035em}h2{font-size:22px;line-height:1.25;margin:0 0 12px}h3{font-size:18px;margin:24px 0 8px}p,li{color:#d9e1f2}.sub{color:var(--mut);margin:0 0 28px}.card{background:linear-gradient(145deg,var(--card2),var(--card));border:1px solid var(--bd);border-radius:17px;padding:26px 29px;margin:0 0 18px}.current{border-color:#31745d;background:linear-gradient(145deg,#102c29,var(--card) 68%)}.warning-card{border-color:#8e6a2b;background:linear-gradient(145deg,#251d15,var(--card) 68%)}.danger-card{border-color:#7a3e49;background:linear-gradient(145deg,#2a161e,var(--card) 68%)}
+    a{color:var(--acc)}code{background:#192341;border:1px solid var(--bd);border-radius:6px;padding:2px 6px}.badge{display:inline-block;margin:0 0 12px;padding:4px 9px;border:1px solid #3a846a;border-radius:999px;color:var(--good);font-size:12px;font-weight:800;letter-spacing:.08em;text-transform:uppercase}.warning{color:var(--warn)}.danger{color:var(--danger)}.table-wrap{overflow-x:auto;margin:18px 0}table{width:100%;min-width:800px;border-collapse:collapse}th,td{padding:13px 14px;border:1px solid var(--bd);text-align:left;vertical-align:top}th{background:#18223b;color:#fff}td{color:#d9e1f2}td strong{color:#fff}.pair{white-space:nowrap}.actions{display:flex;flex-wrap:wrap;gap:10px;margin:18px 0 4px}.button{display:inline-flex;align-items:center;justify-content:center;min-height:44px;padding:9px 14px;border:1px solid #3a527f;border-radius:10px;background:#182542;color:#fff;text-decoration:none;font-weight:750}.button.primary{border-color:transparent;background:linear-gradient(100deg,#287eff,#a94cea 72%,#e647bd)}ol,ul{padding-left:23px}.steps li{margin:9px 0}.note{font-size:14px;color:var(--mut)}nav{margin-top:26px;color:var(--mut)}@media(max-width:600px){body{padding:34px 14px}.card{padding:22px 19px}}
+  </style>
 </head>
 <body><main>
   <h1>Hermes Connector support</h1>
-  <p class="sub">Chrome Web Store transition: public 0.2.0 · candidate/reviewer 0.2.2</p>
-  <div class="card transition" id="compatible-versions"><h2>Choose the matching extension and companion</h2>
-    <p><strong>Check the extension version first:</strong> open <code>chrome://extensions</code>, find Hermes Connector, and read its version. Install only the companion from the same row.</p>
+  <p class="sub">Current Chrome Web Store release: 0.2.2 · protocol 4 · default broker port 8766</p>
+
+  <section class="card current" id="current-release">
+    <span class="badge">Current public release</span>
+    <h2>Install extension 0.2.2 with companion 0.2.2</h2>
+    <p>The Chrome Web Store currently distributes Hermes Connector <strong>0.2.2</strong>. The separately installed local companion must use the same version.</p>
+    <div class="actions">
+      <a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Install from Chrome Web Store</a>
+      <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a>
+      <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/tag/v0.2.2">Release details</a>
+    </div>
+  </section>
+
+  <section class="card" id="compatible-versions">
+    <h2>Extension and companion compatibility</h2>
+    <p>Open <code>chrome://extensions</code>, find Hermes Connector, and read the installed version before downloading a companion. Use only the companion from the same row.</p>
     <div class="table-wrap"><table>
-      <thead><tr><th>Extension installed in Chrome</th><th>Compatible local companion</th><th>Who should use it now</th></tr></thead>
+      <thead><tr><th>Chrome extension</th><th>Matching companion</th><th>Protocol / default port</th><th>When to use</th></tr></thead>
       <tbody>
-        <tr><td><span class="pair"><strong>0.2.0</strong> · <a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">public Chrome Web Store listing</a></span></td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip">Download companion 0.2.0</a><br><small><a href="https://github.com/CorsenAI/hermes-connector/releases/tag/v0.2.0">Open the 0.2.0 release page</a></small></td><td>Everyone whose Chrome extension page currently shows 0.2.0.</td></tr>
-        <tr><td><span class="pair"><strong>0.2.2</strong> · Store candidate/reviewer build</span></td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a><br><small><a href="https://github.com/CorsenAI/hermes-connector/releases/tag/v0.2.2">Open the 0.2.2 release page</a></small></td><td>Google reviewers and users whose Chrome extension page already shows 0.2.2.</td></tr>
+        <tr>
+          <td><span class="pair"><strong>0.2.2</strong> · current Store release</span></td>
+          <td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Companion 0.2.2</a></td>
+          <td>Protocol 4<br><code>127.0.0.1:8766</code></td>
+          <td>Normal installation and all users whose extension page shows 0.2.2.</td>
+        </tr>
+        <tr>
+          <td><span class="pair"><strong>0.2.1</strong> · legacy released/sideloaded build</span></td>
+          <td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip">Companion 0.2.1</a></td>
+          <td>Protocol 4<br><code>127.0.0.1:8766</code></td>
+          <td>Only when Chrome explicitly shows extension 0.2.1. Upgrade to 0.2.2 when possible.</td>
+        </tr>
+        <tr>
+          <td><span class="pair"><strong>0.2.0</strong> · legacy build</span></td>
+          <td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip">Companion 0.2.0</a></td>
+          <td>Protocol 3<br><code>127.0.0.1:8765</code></td>
+          <td>Only while Chrome still shows extension 0.2.0. Follow the disk-recovery notice below.</td>
+        </tr>
       </tbody>
     </table></div>
-    <p class="warning"><strong>Do not mix versions.</strong> Extension 0.2.0 must use companion 0.2.0. Extension 0.2.2 must use companion 0.2.2. Companion 0.2.1 is not part of either Store transition pair.</p>
-  </div>
-  <div class="card"><h2>Install the matching companion</h2><ol>
-    <li>Use the compatibility table above to download the companion that exactly matches the version shown by Chrome, then extract it.</li>
-    <li>On Windows with companion 0.2.0, open PowerShell in the extracted folder and run <code>.\install.ps1</code>. Companion 0.2.2 also lets you double-click <code>Install Hermes Connector.cmd</code>. On macOS/Linux, run <code>./install.sh</code>.</li>
-    <li>Restart any running Hermes dashboard, gateway, or chat process. Re-run the installer after creating a new named Hermes profile.</li>
-    <li>Open the Chrome side panel, paste the private pairing code printed locally, select a Hermes session, and attach only the tabs it may control.</li>
-  </ol></div>
-  <div class="card"><h2>During the 0.2.2 Store review</h2><p>Chrome updates the Web Store extension automatically after Google publishes an approved update, but Chrome cannot update the separately installed local companion.</p><ul>
-    <li><strong>If Chrome still shows 0.2.0:</strong> keep or reinstall companion 0.2.0. Do not install companion 0.2.2 early.</li>
-    <li><strong>When Chrome shows 0.2.2:</strong> install companion 0.2.2, then restart every running Hermes dashboard, gateway, and chat process.</li>
-    <li><strong>If the wrong companion was installed:</strong> run the installer from the correct row above and restart Hermes. Recheck both version numbers before troubleshooting anything else.</li>
-  </ul><p>The default local broker is <code>127.0.0.1:8765</code> for pair 0.2.0 and <code>127.0.0.1:8766</code> for pair 0.2.2.</p></div>
-  <div class="card"><h2>Troubleshooting</h2><ul>
-    <li><strong>Companion offline:</strong> first confirm that the extension and companion versions match. Then confirm Hermes restarted and the matching default port is available: <code>8765</code> for 0.2.0 or <code>8766</code> for 0.2.2.</li>
-    <li><strong>Pairing rejected:</strong> rerun the matching companion installer to display the local pairing code, then save that code again in the extension.</li>
-    <li><strong>Action refused:</strong> select the exact Hermes session and attach a permitted web tab. Restricted Chrome pages cannot be controlled.</li>
-    <li><strong>Debugging banner:</strong> disable Trusted input unless native input or dialog handling is needed.</li>
-  </ul></div>
-  <div class="card"><h2>Contact</h2><p>Report reproducible defects in the <a href="https://github.com/CorsenAI/hermes-connector/issues">public issue tracker</a>. For privacy or security questions, email <a href="mailto:hello@corsen.ai">hello@corsen.ai</a>.</p></div>
+    <p class="warning"><strong>Do not mix versions.</strong> A newer companion is not a compatible upgrade by itself. Update the extension first, then install the companion with exactly the same version.</p>
+  </section>
+
+  <section class="card" id="install">
+    <h2>Install and pair version 0.2.2</h2>
+    <ol class="steps">
+      <li>Install Hermes Connector from the Chrome Web Store and confirm that <code>chrome://extensions</code> shows version <strong>0.2.2</strong>.</li>
+      <li>Download and extract <a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">the 0.2.2 companion</a>.</li>
+      <li>On Windows, double-click <code>Install Hermes Connector.cmd</code>, or run <code>.\install.ps1</code> in PowerShell. On macOS/Linux, run <code>./install.sh</code>.</li>
+      <li>Restart every running Hermes dashboard, gateway, and chat process. Re-run the installer after creating a new named Hermes profile.</li>
+      <li>Open the Chrome side panel, paste the private pairing code printed locally, choose the exact Hermes profile/session, and attach only the tabs it may control.</li>
+    </ol>
+  </section>
+
+  <section class="card warning-card" id="upgrade">
+    <h2>Upgrade from 0.2.0 or 0.2.1</h2>
+    <ol class="steps">
+      <li>Let Chrome update the Web Store extension, then verify that the extension page shows <strong>0.2.2</strong>.</li>
+      <li>Only after Chrome shows 0.2.2, install companion 0.2.2.</li>
+      <li>Restart every running Hermes process. Default installations migrate from legacy port <code>8765</code> to protocol 4 on port <code>8766</code>.</li>
+      <li>If you deliberately configured a custom bridge port, reboot the computer once after installation, or safely stop only the known legacy broker process before restarting Hermes.</li>
+    </ol>
+    <p>Your pairing code is normally preserved by the companion upgrade. If pairing is rejected, rerun the matching installer and save the locally displayed code again.</p>
+  </section>
+
+  <section class="card danger-card" id="leveldb-recovery">
+    <h2>Version 0.2.0 disk-growth recovery</h2>
+    <p>Version 0.2.0 could repeatedly write extension state and enlarge Chrome's LevelDB journal. Version 0.2.1 and later stop the known repeated writes, but Chrome may not immediately reclaim disk space that was already consumed.</p>
+    <ol class="steps">
+      <li>Upgrade the extension and companion to matching version 0.2.2.</li>
+      <li>Close <strong>every</strong> Chrome window completely, wait for Chrome processes to exit, and reopen Chrome.</li>
+      <li>If the extension's storage remains abnormally large, remove and reinstall Hermes Connector from the Chrome Web Store. This clears this extension's local settings.</li>
+      <li>Paste the pairing code again, name the Chrome profile if required, reselect the Hermes session, and reattach the permitted tabs.</li>
+    </ol>
+    <p class="danger"><strong>Do not manually delete arbitrary files from the Chrome profile.</strong> Removing the extension clears its settings, including pairing and tab/session bindings, but does not remove the separately installed Hermes companion.</p>
+  </section>
+
+  <section class="card" id="troubleshooting">
+    <h2>Troubleshooting</h2>
+    <ul>
+      <li><strong>Companion offline:</strong> verify that extension and companion versions match, restart Hermes, and confirm that the matching default port is available: <code>8766</code> for 0.2.1/0.2.2 or <code>8765</code> for 0.2.0.</li>
+      <li><strong>Pairing rejected:</strong> rerun the matching companion installer to display the current local pairing code, then save it again in the extension.</li>
+      <li><strong>Action refused:</strong> select the exact Hermes session and attach a permitted normal web tab. Chrome internal pages and other restricted pages cannot be controlled.</li>
+      <li><strong>Wrong tab or stale session:</strong> detach the tab, select the intended session, and attach it again. The connector fails closed instead of silently using another active tab.</li>
+      <li><strong>Chrome debugging banner:</strong> disable Trusted input unless native input events or dialog handling are required.</li>
+    </ul>
+  </section>
+
+  <section class="card" id="contact">
+    <h2>Contact</h2>
+    <p>Report reproducible defects in the <a href="https://github.com/CorsenAI/hermes-connector/issues">public issue tracker</a>. For privacy or security questions, email <a href="mailto:hello@corsen.ai">hello@corsen.ai</a>.</p>
+    <p class="note">Hermes Connector is an unofficial community project by Corsen AI. It is not affiliated with or endorsed by Nous Research or Google.</p>
+  </section>
+
   <nav><a href="../">Home</a> · <a href="../privacy/">Privacy policy</a> · <a href="https://github.com/CorsenAI/hermes-connector">Source code</a></nav>
 </main></body>
 </html>


### PR DESCRIPTION
## Summary

- make Chrome Web Store 0.2.2 and companion 0.2.2 the current public installation path
- retain exact compatibility and download paths for released 0.2.1 and legacy 0.2.0
- restore the 0.2.0 LevelDB disk-growth recovery procedure
- align the public homepage, README, and sitemap
- document protocol and default-port differences without encouraging mixed-version installs

## Validation

- HTML parsed successfully
- JSON-LD parsed successfully
- internal anchors validated
- sitemap parsed as XML
- release/download links checked against GitHub releases
- current Chrome Web Store version verified as 0.2.2

## Addresses

- PR #3 review comment `discussion_r3700837510`
- PR #3 review comment `discussion_r3700837513`
