### PR TITLE
Release Hermes Connector 0.2.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@ LICENSE text eol=lf
 *.md text eol=lf
 *.py text eol=lf
 *.sh text eol=lf
+*.xml text eol=lf
 *.yaml text eol=lf
 *.yml text eol=lf
 *.cmd text eol=crlf

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -28,13 +28,15 @@ separately under the same release version.
 
 - Privacy: `https://corsenai.github.io/hermes-connector/privacy/`
 - Support and installation: `https://corsenai.github.io/hermes-connector/support/`
-- Companion 0.2.2: `https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip`
+- Companion 0.2.3: `https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.3/hermes-connector-0.2.3-companion.zip`
 - Source: `https://github.com/CorsenAI/hermes-connector`
 - Support email: `hello@corsen.ai`
 
 The public pages are deployed from `docs/` in the source repository. Publish
-the companion archive and release manifest under the matching GitHub release
-before submitting the Store item.
+the companion archive and release manifest under a public matching GitHub
+**prerelease** before submitting the Store item. Keep that release marked as a
+prerelease—not Latest—while Google still distributes the previous Store
+version. Promote it to a normal Latest release only at the Store cutover.
 - Ensure the Corsen AI developer account has 2-Step Verification enabled.
 - Do not submit until the privacy page, companion download, and review
   instructions are public.
@@ -148,12 +150,27 @@ so use deferred publishing and answer reviewer questions promptly.
 - [ ] Submit for review with deferred publishing; publish only after approval
       and final artifact/hash verification.
 
-## 8. Post-publication verification
+## 8. Approval, public cutover, and verification
 
-- [ ] Confirm the public Store endpoint serves version 0.2.2 for the existing
-      extension ID.
+- [ ] Wait until Google reports the submission as approved and staged under
+      deferred publishing. Prepare, but do not yet merge, a documentation
+      cutover commit that replaces the temporary 0.2.2-public /
+      0.2.3-candidate wording in
+      `README.md`, `docs/index.html`, and `docs/support/index.html`: make 0.2.3
+      the public/current pair, move 0.2.2 to legacy, keep the primary companion
+      CTAs version-neutral, and update the compatibility tables plus homepage
+      JSON-LD version/download URL to 0.2.3.
+- [ ] Run the complete release gate on the prepared cutover commit.
+- [ ] Publish the approved 0.2.3 package from the existing Chrome Web Store
+      item. Do not create a new item or change the extension ID.
+- [ ] Merge the prepared documentation cutover immediately, then wait for the
+      matching GitHub Pages deployment.
+- [ ] Promote GitHub v0.2.3 from prerelease to a normal release and mark it
+      Latest.
+- [ ] Confirm both that the public Store endpoint serves version 0.2.3 for the
+      existing extension ID and that Pages serves the cutover documentation.
 - [ ] Smoke-test the Store-installed build in the intended signed-in Chrome
-      profile and confirm an upgraded 0.2.0 profile receives the companion
+      profile and confirm an upgraded 0.2.2 profile receives the companion
       reinstall notice.
 
 Official references: Chrome Web Store documentation for

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ automation browser or guessing which tab belongs to which task.
 
 ![Hermes Connector — local AI, your tabs](store/promo-marquee-1400x560.png)
 
-[**Install version 0.2.2 from the Chrome Web Store**](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm)
+[**Install from the Chrome Web Store**](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm)
 · [Watch the complete installation and live browser-control demo](https://youtu.be/4akSq9cMmFw)
 · [Setup guide](https://corsenai.github.io/hermes-connector/)
-· [Download companion 0.2.2](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip)
+· [Choose the matching companion](https://corsenai.github.io/hermes-connector/support/#compatible-versions)
 · [Get support](https://corsenai.github.io/hermes-connector/support/)
 
 > Unofficial community project by Corsen AI. Not affiliated with or endorsed
@@ -18,12 +18,15 @@ automation browser or guessing which tab belongs to which task.
 
 ## Current release and compatibility
 
-The public Chrome Web Store release is **0.2.2**. The Chrome extension and local
-companion must use exactly the same version.
+The public Chrome Web Store build is **0.2.2** while **0.2.3** is the candidate
+prepared for review. Install the companion only after checking the extension
+version in `chrome://extensions`; the Chrome extension and local companion must
+use exactly the same version.
 
 | Chrome extension | Matching companion | Protocol / default broker | Status |
 | --- | --- | --- | --- |
-| 0.2.2 | [Companion 0.2.2](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip) | Protocol 4 / `127.0.0.1:8766` | Current public release |
+| 0.2.2 | [Companion 0.2.2](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip) | Protocol 4 / `127.0.0.1:8766` | Current public Store pair |
+| 0.2.3 | [Companion 0.2.3](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.3/hermes-connector-0.2.3-companion.zip) | Protocol 4 / `127.0.0.1:8766` | Store candidate/reviewer pair; use only when Chrome shows 0.2.3 |
 | 0.2.1 | [Companion 0.2.1](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip) | Protocol 4 / `127.0.0.1:8766` | Legacy released or sideloaded pair |
 | 0.2.0 | [Companion 0.2.0](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip) | Protocol 3 / `127.0.0.1:8765` | Legacy pair; see the disk-recovery procedure |
 
@@ -89,7 +92,7 @@ the appropriate Windows, macOS, or Linux instructions.
 ### 1. Install the Chrome extension
 
 [Install Hermes Connector from the Chrome Web Store](https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm),
-verify that `chrome://extensions` shows version **0.2.2**, then click its toolbar
+check the version shown in `chrome://extensions`, then click its toolbar
 icon or press `Ctrl+Shift+H` (`Command+Shift+H` on macOS) to open the side panel.
 
 ### 2. Let the extension check the companion
@@ -100,8 +103,8 @@ It does not send this check to the internet.
 - If the panel says the matching companion is already reachable, do not reinstall it.
 - Otherwise, use the panel's **Download companion** button and extract the ZIP.
 
-The current matching download is
-[`hermes-connector-0.2.2-companion.zip`](https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip).
+Use the compatibility table above to download the companion whose version
+exactly matches the extension version shown by Chrome.
 
 ### 3. Install the companion once
 

--- a/docs/ACCEPTANCE.md
+++ b/docs/ACCEPTANCE.md
@@ -53,7 +53,7 @@ the final packaged bits.
 - [x] End-to-end runs are completed in one and two isolated Chrome profiles.
 - [ ] A pre-submit end-to-end run loads the exact packaged ZIP in the intended
       signed-in Google Chrome profile.
-- [ ] After publication, the existing Store ID serves 0.2.2 and its installed
+- [ ] After publication, the existing Store ID serves 0.2.3 and its installed
       build passes a signed-in-profile smoke test.
 
 Evidence for checked gates is recorded in `TEST-EVIDENCE.md`.

--- a/docs/TEST-EVIDENCE.md
+++ b/docs/TEST-EVIDENCE.md
@@ -36,9 +36,22 @@ The public product screenshot and video remain identified as 0.2.2 captures.
 The 0.2.3 patch does not change the depicted product UI, so their provenance is
 preserved rather than relabelled.
 
+### Clean packaged artifacts
+
+The deterministic clean build reports `sourceDirty: false`. Its publishable
+archives are:
+
+- `hermes-connector-0.2.3-chrome.zip` — 57,590 bytes — SHA-256
+  `039d0b569f623a70e8c1f180a3372595d7f733d3160bc195dc1c52864edfc3e7`;
+- `hermes-connector-0.2.3-companion.zip` — 28,220 bytes — SHA-256
+  `32fbae02a31874af223cdd06bcce7e02443fa366a0327cc06419aec6db9f55f6`.
+
+The exact extracted Chrome and companion ZIP pair passes both the single-browser
+and two-browser real Chrome acceptance suites. The final release manifest must
+record the tagged source commit and the same deterministic archive hashes.
+
 ### Remaining 0.2.3 external release evidence
 
-- build the exact clean 0.2.3 archives and record their SHA-256 values;
 - pass the release gate on Windows, macOS, and Ubuntu for the final tagged commit;
 - publish the matching GitHub 0.2.3 companion before changing the Store item;
 - upload the 0.2.3 Chrome ZIP to the existing Store item with deferred publishing;

--- a/docs/TEST-EVIDENCE.md
+++ b/docs/TEST-EVIDENCE.md
@@ -1,6 +1,53 @@
-# Test evidence — 2026-08-03 — 0.2.2 release candidate
+# Test evidence
 
-## Why 0.2.2 was required
+## 0.2.3 release candidate — 2026-08-31
+
+### Why 0.2.3 is required
+
+The 0.2.2 companion launched its Windows broker with
+`CREATE_NO_WINDOW | DETACHED_PROCESS`, even though Windows ignores
+`CREATE_NO_WINDOW` in that combination. It also inherited independently opened
+`broker.log` handles whose MSVCRT append positions could race between processes,
+and used a raw TCP readiness probe that could leave invalid WebSocket handshake
+noise in the log.
+
+The reconciled fix on `main` removes `DETACHED_PROCESS`, keeps
+`CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW`, opens the Windows log with
+kernel-enforced `FILE_APPEND_DATA` semantics, and performs a protocol-valid
+WebSocket upgrade for readiness. The 0.2.3 release bump also makes Chrome show a
+new companion-reinstallation notice to users upgrading from 0.2.2.
+
+### Local release-candidate validation
+
+The fast gate passes on Windows with Python 3.11 and Node.js 24:
+
+- the 64-test Python suite is green (58 passed and six platform/privilege skips),
+  including the native two-process Windows append test, the explicit
+  no-`DETACHED_PROCESS` launch assertion, and the valid WebSocket readiness probe;
+- 19 JavaScript tests pass, including the 0.2.2-to-0.2.3 upgrade notice;
+- both the PowerShell installer and normal-user double-click `.cmd` path install
+  companion 0.2.3 and verify the installed payload version;
+- the real single-browser Chrome acceptance passes every advertised action,
+  upgrade notice, exact routing, and fail-closed check;
+- the real two-browser acceptance passes concurrent isolated profiles,
+  ownership transfer, and stale-owner revocation.
+
+The public product screenshot and video remain identified as 0.2.2 captures.
+The 0.2.3 patch does not change the depicted product UI, so their provenance is
+preserved rather than relabelled.
+
+### Remaining 0.2.3 external release evidence
+
+- build the exact clean 0.2.3 archives and record their SHA-256 values;
+- pass the release gate on Windows, macOS, and Ubuntu for the final tagged commit;
+- publish the matching GitHub 0.2.3 companion before changing the Store item;
+- upload the 0.2.3 Chrome ZIP to the existing Store item with deferred publishing;
+- after approval, publish and confirm that the existing Store ID serves 0.2.3,
+  then smoke-test the Store-installed build.
+
+## Historical evidence — 2026-08-03 — 0.2.2 release candidate
+
+### Why 0.2.2 was required
 
 The public Store endpoint still served 0.2.0 while the 0.2.1 submission was
 being evaluated. A deeper audit found that 0.2.1 was not ready to be treated as
@@ -31,7 +78,7 @@ moves secondary controls into compact accessible overlays. The installer now
 verifies every installed companion file byte-for-byte and rolls back on any
 post-publication verification failure.
 
-## Why 0.2.1 was required (historical)
+### Why 0.2.1 was required (historical)
 
 The public 0.2.0 package was installable, but final use exposed production
 paths that the isolated release tests had not covered:
@@ -50,7 +97,7 @@ paths that the isolated release tests had not covered:
 The data growth was local Chrome storage churn, not network transmission or a
 publisher data leak.
 
-## Fast release gate
+### Fast release gate
 
 Command:
 
@@ -88,7 +135,7 @@ New regression evidence includes:
   symlink/reparse redirection, and an interruption between payload swaps restores
   the previous installation.
 
-## Real Chrome extension acceptance
+### Real Chrome extension acceptance
 
 Commands:
 
@@ -114,7 +161,7 @@ The two-browser run verifies two concurrent isolated Chrome profiles, stable
 browser identities, exact routing, explicit ownership transfer, stale-owner
 revocation, and fail-closed behavior after displacement.
 
-## Broker recovery
+### Broker recovery
 
 An isolated live recovery probe started a real detached broker, killed the
 exact broker process owning its random test port, kept the same `BridgeClient`
@@ -131,7 +178,7 @@ legacy owner only once, ignores a late write from a still-running protocol-3
 broker, refuses fallback from a present invalid v4 snapshot, and uses distinct
 complete temporary files for concurrent atomic saves.
 
-## Multi-profile installation
+### Multi-profile installation
 
 The 0.2.2 source installer is tested without printing the pairing secret.
 The shared home and every discovered named profile report
@@ -146,7 +193,7 @@ named `hermes` cannot break Python discovery. The same Windows gate executes
 the normal-user `Install Hermes Connector.cmd` double-click path. Users must re-run the companion
 installer after creating a new named profile.
 
-## Store artwork and verified live capture
+### Store artwork and verified live capture
 
 `store/screenshot-product-1280x800.png` is an exact 1280×800 OS-window capture
 from the real 0.2.2 candidate. In an isolated profile, a real Hermes model called
@@ -170,12 +217,9 @@ checked for valid contrast, the real Tabs open/close transition, and agreement
 with the unobstructed final OS-window capture. SHA-256:
 `DE91F39FC9E5CE225097F255CB620D324B47A436BD9BA034D1C608A4F01F239D`.
 
-## Remaining external release evidence
+### Completed 0.2.2 distribution evidence
 
-- build the exact clean 0.2.2 archives and record their SHA-256 values;
-- publish the matching GitHub 0.2.2 companion before changing the Store item;
-- upload the 0.2.2 Chrome ZIP and verified replacement screenshot to the Store;
-- complete a pre-submit pass from the exact extracted ZIP in the intended
-  signed-in Chrome profile;
-- after publication, confirm the existing Store ID serves 0.2.2 and smoke-test
-  that Store-installed build.
+GitHub release v0.2.2 and its three version-matched artifacts were published,
+the existing Chrome Web Store item was updated to 0.2.2, and the public Pages
+documentation was aligned with that Store pair. The later Windows reliability
+fix is intentionally distributed as 0.2.3 rather than replacing 0.2.2 assets.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     "applicationCategory": "BrowserApplication",
     "operatingSystem": "Google Chrome 120+ on Windows, macOS, and Linux",
     "softwareVersion": "0.2.2",
-    "dateModified": "2026-08-12",
+    "dateModified": "2026-08-31",
     "description": "An unofficial Chrome browser extension that connects exact local Hermes Agent sessions to user-selected tabs in a real signed-in Chrome profile.",
     "image": "https://raw.githubusercontent.com/CorsenAI/hermes-connector/main/store/store-icon-128.png",
     "softwareRequirements": "Google Chrome 120 or later, a local Hermes installation, and the matching Hermes Connector companion",
@@ -259,10 +259,10 @@
           <p class="lead">Hermes Connector links exact local Hermes Agent sessions to only the Chrome tabs you attach—inside the signed-in browser profile you already use.</p>
           <div class="actions">
             <a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Add to Chrome</a>
-            <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a>
+            <a class="button" href="support/#compatible-versions">Choose matching companion</a>
             <a class="button" href="https://youtu.be/4akSq9cMmFw" target="_blank" rel="noopener noreferrer">Watch the complete demo</a>
           </div>
-          <p class="microcopy">Current public pair: extension 0.2.2 + companion 0.2.2</p>
+          <p class="microcopy">Public Store pair: 0.2.2 · Candidate/reviewer pair: 0.2.3</p>
         </div>
 
         <figure class="product-frame hero-visual">
@@ -272,13 +272,14 @@
       </div>
 
       <div class="wrap card transition" role="note" aria-labelledby="version-match-title">
-        <p class="kicker">Current Chrome Web Store release</p>
+        <p class="kicker">Store update pending</p>
         <h2 id="version-match-title">Match the local companion to the extension version shown by Chrome.</h2>
         <p>Open <code>chrome://extensions</code> and check Hermes Connector before downloading the local companion.</p>
         <div class="compatibility-scroll"><table class="compatibility">
           <thead><tr><th>Extension installed in Chrome</th><th>Compatible local companion</th><th>Use this pair when</th></tr></thead>
           <tbody>
-            <tr><td><strong>0.2.2</strong> from the <a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">current Chrome Web Store listing</a></td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a></td><td>Normal installation and every user whose extension page shows 0.2.2.</td></tr>
+            <tr><td><strong>0.2.2</strong> from the <a href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">public Chrome Web Store listing</a></td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a></td><td>Everyone whose extension page currently shows 0.2.2.</td></tr>
+            <tr><td><strong>0.2.3</strong> Store candidate/reviewer build</td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.3/hermes-connector-0.2.3-companion.zip">Download companion 0.2.3</a></td><td>Google review or Chrome already shows extension version 0.2.3.</td></tr>
             <tr><td><strong>0.2.1</strong> legacy released or sideloaded build</td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip">Download companion 0.2.1</a></td><td>Only while Chrome explicitly shows extension version 0.2.1.</td></tr>
             <tr><td><strong>0.2.0</strong> legacy build</td><td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.0/hermes-connector-0.2.0-companion.zip">Download companion 0.2.0</a></td><td>Only while Chrome explicitly shows 0.2.0. Follow the <a href="support/#leveldb-recovery">disk-recovery procedure</a>.</td></tr>
           </tbody>
@@ -384,7 +385,7 @@
           <div class="requirements-row"><strong>Browser</strong><span>Google Chrome 120 or later.</span></div>
           <div class="requirements-row"><strong>Hermes</strong><span>A working local Hermes installation on the same computer.</span></div>
           <div class="requirements-row"><strong>Companion</strong><span>The Hermes Connector companion with exactly the same version as the extension, installed once for existing profiles and again after creating a new named Hermes profile.</span></div>
-          <div class="requirements-row"><strong>Operating system</strong><span>Windows, macOS, or Linux. Windows uses <code>.\install.ps1</code>; companion 0.2.2 also includes a double-click launcher. macOS and Linux use <code>./install.sh</code>.</span></div>
+          <div class="requirements-row"><strong>Operating system</strong><span>Windows, macOS, or Linux. Windows uses <code>.\install.ps1</code>; companion 0.2.2 and later also include a double-click launcher. macOS and Linux use <code>./install.sh</code>.</span></div>
         </div>
       </div>
     </section>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://corsenai.github.io/hermes-connector/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-31</lastmod>
   </url>
   <url>
     <loc>https://corsenai.github.io/hermes-connector/support/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-31</lastmod>
   </url>
   <url>
     <loc>https://corsenai.github.io/hermes-connector/privacy/</loc>

--- a/docs/support/index.html
+++ b/docs/support/index.html
@@ -27,16 +27,16 @@
 </head>
 <body><main>
   <h1>Hermes Connector support</h1>
-  <p class="sub">Current Chrome Web Store release: 0.2.2 · protocol 4 · default broker port 8766</p>
+  <p class="sub">Chrome Web Store transition: public 0.2.2 · candidate/reviewer 0.2.3</p>
 
   <section class="card current" id="current-release">
-    <span class="badge">Current public release</span>
-    <h2>Install extension 0.2.2 with companion 0.2.2</h2>
-    <p>The Chrome Web Store currently distributes Hermes Connector <strong>0.2.2</strong>. The separately installed local companion must use the same version.</p>
+    <span class="badge">Store update pending</span>
+    <h2>Match the companion to the extension version shown by Chrome</h2>
+    <p>The Store currently serves 0.2.2. Install companion 0.2.3 only for the reviewer build or after <code>chrome://extensions</code> shows Hermes Connector <strong>0.2.3</strong>.</p>
     <div class="actions">
       <a class="button primary" href="https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm">Install from Chrome Web Store</a>
-      <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Download companion 0.2.2</a>
-      <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/tag/v0.2.2">Release details</a>
+      <a class="button" href="#compatible-versions">Choose matching companion</a>
+      <a class="button" href="https://github.com/CorsenAI/hermes-connector/releases/tag/v0.2.3">Open 0.2.3 candidate details</a>
       <a class="button" href="https://youtu.be/4akSq9cMmFw" target="_blank" rel="noopener noreferrer">Watch installation and demo</a>
     </div>
   </section>
@@ -48,16 +48,22 @@
       <thead><tr><th>Chrome extension</th><th>Matching companion</th><th>Protocol / default port</th><th>When to use</th></tr></thead>
       <tbody>
         <tr>
-          <td><span class="pair"><strong>0.2.2</strong> · current Store release</span></td>
+          <td><span class="pair"><strong>0.2.2</strong> · current public Store build</span></td>
           <td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">Companion 0.2.2</a></td>
           <td>Protocol 4<br><code>127.0.0.1:8766</code></td>
-          <td>Normal installation and all users whose extension page shows 0.2.2.</td>
+          <td>Everyone whose Chrome extension page currently shows 0.2.2.</td>
+        </tr>
+        <tr>
+          <td><span class="pair"><strong>0.2.3</strong> · Store candidate/reviewer build</span></td>
+          <td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.3/hermes-connector-0.2.3-companion.zip">Companion 0.2.3</a></td>
+          <td>Protocol 4<br><code>127.0.0.1:8766</code></td>
+          <td>Google reviewers and users whose Chrome extension page already shows 0.2.3.</td>
         </tr>
         <tr>
           <td><span class="pair"><strong>0.2.1</strong> · legacy released/sideloaded build</span></td>
           <td><a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.1/hermes-connector-0.2.1-companion.zip">Companion 0.2.1</a></td>
           <td>Protocol 4<br><code>127.0.0.1:8766</code></td>
-          <td>Only when Chrome explicitly shows extension 0.2.1. Upgrade to 0.2.2 when possible.</td>
+          <td>Only when Chrome explicitly shows extension 0.2.1. Upgrade to 0.2.3 when possible.</td>
         </tr>
         <tr>
           <td><span class="pair"><strong>0.2.0</strong> · legacy build</span></td>
@@ -71,10 +77,10 @@
   </section>
 
   <section class="card" id="install">
-    <h2>Install and pair version 0.2.2</h2>
+    <h2>Install and pair the matching version</h2>
     <ol class="steps">
-      <li>Install Hermes Connector from the Chrome Web Store and confirm that <code>chrome://extensions</code> shows version <strong>0.2.2</strong>.</li>
-      <li>Download and extract <a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip">the 0.2.2 companion</a>.</li>
+      <li>Install Hermes Connector from the Chrome Web Store and read its version in <code>chrome://extensions</code>.</li>
+      <li>Download and extract the companion from the matching row above.</li>
       <li>On Windows, double-click <code>Install Hermes Connector.cmd</code>, or run <code>.\install.ps1</code> in PowerShell. On macOS/Linux, run <code>./install.sh</code>.</li>
       <li>Restart every running Hermes dashboard, gateway, and chat process. Re-run the installer after creating a new named Hermes profile.</li>
       <li>Open the Chrome side panel, paste the private pairing code printed locally, choose the exact Hermes profile/session, and attach only the tabs it may control.</li>
@@ -82,10 +88,10 @@
   </section>
 
   <section class="card warning-card" id="upgrade">
-    <h2>Upgrade from 0.2.0 or 0.2.1</h2>
+    <h2>Before and during the 0.2.3 Store review</h2>
     <ol class="steps">
-      <li>Let Chrome update the Web Store extension, then verify that the extension page shows <strong>0.2.2</strong>.</li>
-      <li>Only after Chrome shows 0.2.2, install companion 0.2.2.</li>
+      <li>If Chrome still shows 0.2.2, keep or reinstall companion 0.2.2. Do not install companion 0.2.3 early.</li>
+      <li>When Chrome shows 0.2.3, install companion 0.2.3.</li>
       <li>Restart every running Hermes process. Default installations migrate from legacy port <code>8765</code> to protocol 4 on port <code>8766</code>.</li>
       <li>If you deliberately configured a custom bridge port, reboot the computer once after installation, or safely stop only the known legacy broker process before restarting Hermes.</li>
     </ol>
@@ -96,7 +102,7 @@
     <h2>Version 0.2.0 disk-growth recovery</h2>
     <p>Version 0.2.0 could repeatedly write extension state and enlarge Chrome's LevelDB journal. Version 0.2.1 and later stop the known repeated writes, but Chrome may not immediately reclaim disk space that was already consumed.</p>
     <ol class="steps">
-      <li>Upgrade the extension and companion to matching version 0.2.2.</li>
+      <li>Upgrade the extension and companion to the latest matching version shown by Chrome.</li>
       <li>Close <strong>every</strong> Chrome window completely, wait for Chrome processes to exit, and reopen Chrome.</li>
       <li>If the extension's storage remains abnormally large, remove and reinstall Hermes Connector from the Chrome Web Store. This clears this extension's local settings.</li>
       <li>Paste the pairing code again, name the Chrome profile if required, reselect the Hermes session, and reattach the permitted tabs.</li>
@@ -107,7 +113,7 @@
   <section class="card" id="troubleshooting">
     <h2>Troubleshooting</h2>
     <ul>
-      <li><strong>Companion offline:</strong> verify that extension and companion versions match, restart Hermes, and confirm that the matching default port is available: <code>8766</code> for 0.2.1/0.2.2 or <code>8765</code> for 0.2.0.</li>
+      <li><strong>Companion offline:</strong> verify that extension and companion versions match, restart Hermes, and confirm that the matching default port is available: <code>8766</code> for 0.2.1/0.2.2/0.2.3 or <code>8765</code> for 0.2.0.</li>
       <li><strong>Pairing rejected:</strong> rerun the matching companion installer to display the current local pairing code, then save it again in the extension.</li>
       <li><strong>Action refused:</strong> select the exact Hermes session and attach a permitted normal web tab. Chrome internal pages and other restricted pages cannot be controlled.</li>
       <li><strong>Wrong tab or stale session:</strong> detach the tab, select the intended session, and attach it again. The connector fails closed instead of silently using another active tab.</li>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hermes Connector — by Corsen AI",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Attach real Hermes sessions to chosen tabs in your signed-in Chrome profile. Local, unofficial, by Corsen AI.",
   "homepage_url": "https://corsenai.github.io/hermes-connector/",
   "minimum_chrome_version": "120",

--- a/extension/src/sidepanel.html
+++ b/extension/src/sidepanel.html
@@ -110,8 +110,8 @@
     </details>
     <div class="setupActions">
       <a id="downloadCompanion" class="primaryLink"
-        href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip"
-        target="_blank" rel="noopener noreferrer">Download companion 0.2.2</a>
+        href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.3/hermes-connector-0.2.3-companion.zip"
+        target="_blank" rel="noopener noreferrer">Download companion 0.2.3</a>
       <a href="https://corsenai.github.io/hermes-connector/support/" target="_blank"
         rel="noopener noreferrer">Detailed instructions</a>
       <button id="openSetupSettings">Enter pairing code</button>
@@ -120,10 +120,10 @@
   </aside>
   <aside id="upgradeNotice" role="alertdialog" aria-modal="true" aria-labelledby="upgradeTitle" hidden>
     <strong id="upgradeTitle">Companion update required</strong>
-    <p>Re-download and run the 0.2.2 companion installer, then restart running Hermes processes.
+    <p>Re-download and run the 0.2.3 companion installer, then restart running Hermes processes.
       Browser tools may fail until this is done.</p>
     <p id="customPortUpgrade" hidden><b>Custom bridge port:</b> an older detached broker may still own it.
-      After installing 0.2.2, reboot this computer once (or safely stop only that legacy broker),
+      After installing 0.2.3, reboot this computer once (or safely stop only that legacy broker),
       then start Hermes again.</p>
     <div class="upgradeActions">
       <a href="https://corsenai.github.io/hermes-connector/support/" target="_blank"
@@ -141,7 +141,7 @@
     <label>Pairing code (from companion installer)
       <input id="pairingCode" type="password" spellcheck="false" placeholder="paste the installer's private code" /></label>
     <div class="setupActions">
-      <a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip"
+      <a href="https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.3/hermes-connector-0.2.3-companion.zip"
         target="_blank" rel="noopener noreferrer">Download companion</a>
       <a href="https://corsenai.github.io/hermes-connector/support/" target="_blank"
         rel="noopener noreferrer">Setup help</a>

--- a/extension/src/sidepanel.js
+++ b/extension/src/sidepanel.js
@@ -247,7 +247,7 @@ function renderCompanionDetection(detected, checking = false) {
   renderPlatformInstallStep();
   setupStepRestart.textContent = "Restart Hermes, then copy the private pairing code the installer displays.";
   setupStepPair.textContent = "Paste that code below, choose a Hermes session, and attach only the tabs it may use.";
-  downloadCompanion.textContent = "Download companion 0.2.2";
+  downloadCompanion.textContent = "Download companion 0.2.3";
   if (!setupNotice.hidden) statusEl.textContent = "setup required — companion not reachable";
 }
 

--- a/hermes-plugin/plugin.yaml
+++ b/hermes-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-connector
-version: 0.2.2
+version: 0.2.3
 manifest_version: 1
 description: >-
   Attach exact Hermes profiles and sessions to user-selected tabs in paired,

--- a/store/LISTING.md
+++ b/store/LISTING.md
@@ -1,12 +1,12 @@
-# Chrome Web Store listing — Hermes Connector 0.2.2
+# Chrome Web Store listing — Hermes Connector 0.2.3
 
-Upload: `dist/hermes-connector-0.2.2-chrome.zip`
+Upload: `dist/hermes-connector-0.2.3-chrome.zip`
 
 Privacy policy: `https://corsenai.github.io/hermes-connector/privacy/`
 
 Support: `https://corsenai.github.io/hermes-connector/support/`
 
-Companion download: `https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.2/hermes-connector-0.2.2-companion.zip`
+Companion download: `https://github.com/CorsenAI/hermes-connector/releases/download/v0.2.3/hermes-connector-0.2.3-companion.zip`
 
 Source: `https://github.com/CorsenAI/hermes-connector`
 
@@ -16,7 +16,9 @@ Source: `https://github.com/CorsenAI/hermes-connector`
 - Small promo: `store/promo-small-440x280.png` (440×280)
 - Marquee promo: `store/promo-marquee-1400x560.png` (1400×560)
 - Verified live E2E capture: `store/screenshot-product-1280x800.png` (1280×800).
-  It shows the real 0.2.2 candidate, matching companion, real Hermes model
+  It shows the unchanged product UI exercised by the verified 0.2.2 live
+  acceptance capture; the 0.2.3 patch changes only companion reliability,
+  versioned download guidance, and regression coverage. The capture shows real Hermes model
   calls, and the exact attached public `example.com` tab in an isolated profile.
 
 ## Item name
@@ -94,7 +96,7 @@ installed by double-clicking “Install Hermes Connector.cmd”.
 
 UPGRADING FROM AN OLDER VERSION
 
-Chrome updates the extension automatically, but the local companion must be downloaded and installed again. Restart running Hermes processes after installing companion 0.2.2. Default installations migrate automatically from the legacy local port to protocol 4 on port 8766. If you deliberately configured a custom bridge port, the in-extension notice links to the one-time legacy-broker shutdown/reboot step. The notice remains visible until you confirm the update.
+Chrome updates the extension automatically, but the local companion must be downloaded and installed again. Restart running Hermes processes after installing companion 0.2.3. Default installations migrate automatically from the legacy local port to protocol 4 on port 8766. If you deliberately configured a custom bridge port, the in-extension notice links to the one-time legacy-broker shutdown/reboot step. The notice remains visible until you confirm the update.
 
 Hermes Connector is an unofficial community extension by Corsen AI. It is not affiliated with or endorsed by Nous Research or Google.
 

--- a/tests/background-bindings.test.mjs
+++ b/tests/background-bindings.test.mjs
@@ -45,7 +45,7 @@ test("read-only tab rendering does not write or rebroadcast unchanged bindings",
     },
     permissions: { async contains() { return false; } },
     runtime: {
-      getManifest() { return { version: "0.2.2" }; },
+      getManifest() { return { version: "0.2.3" }; },
       onInstalled: installedEvent,
       onMessage: runtimeEvent,
       async sendMessage(message) { runtimeMessages.push(message); },
@@ -89,13 +89,13 @@ test("read-only tab rendering does not write or rebroadcast unchanged bindings",
   assert.equal(installedEvent.listeners.length, 1);
   const onInstalled = installedEvent.listeners[0];
   onInstalled({ reason: "install" });
-  onInstalled({ reason: "update", previousVersion: "0.2.2" });
+  onInstalled({ reason: "update", previousVersion: "0.2.3" });
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(storage.upgradeNotice, undefined);
-  onInstalled({ reason: "update", previousVersion: "0.2.1" });
+  onInstalled({ reason: "update", previousVersion: "0.2.2" });
   await new Promise((resolve) => setTimeout(resolve, 10));
-  assert.equal(storage.upgradeNotice.id, "companion-reinstall-0.2.2");
-  assert.equal(storage.upgradeNotice.previousVersion, "0.2.1");
+  assert.equal(storage.upgradeNotice.id, "companion-reinstall-0.2.3");
+  assert.equal(storage.upgradeNotice.previousVersion, "0.2.2");
   assert.equal(storage.upgradeNotice.customBridge, false);
   assert.equal(storage.settings.bridgeUrl, "ws://127.0.0.1:8766");
   assert.deepEqual(storage.bridgeMigration021, { completed: true, customBridge: false });
@@ -134,8 +134,8 @@ test("read-only tab rendering does not write or rebroadcast unchanged bindings",
   });
 
   let noticeResult = await send({ cmd: "dismissUpgradeNotice", id: "future-notice" });
-  assert.equal(noticeResult.upgradeNotice.id, "companion-reinstall-0.2.2");
-  noticeResult = await send({ cmd: "dismissUpgradeNotice", id: "companion-reinstall-0.2.2" });
+  assert.equal(noticeResult.upgradeNotice.id, "companion-reinstall-0.2.3");
+  noticeResult = await send({ cmd: "dismissUpgradeNotice", id: "companion-reinstall-0.2.3" });
   assert.equal(noticeResult.upgradeNotice, null);
   assert.equal(storage.upgradeNotice, undefined);
 

--- a/tests/background-session.test.mjs
+++ b/tests/background-session.test.mjs
@@ -107,7 +107,7 @@ test("actions stay bound to their authenticated socket and current tab authoriza
     },
     permissions: { async contains() { return false; } },
     runtime: {
-      getManifest() { return { version: "0.2.2" }; },
+      getManifest() { return { version: "0.2.3" }; },
       onInstalled: simpleEvent(),
       onMessage: runtimeEvent,
       async sendMessage() {},

--- a/tests/background-tabs.test.mjs
+++ b/tests/background-tabs.test.mjs
@@ -113,7 +113,7 @@ test("active-tab reporting rejects restricted pages without changing the scoped 
     },
     permissions: { async contains() { return false; } },
     runtime: {
-      getManifest() { return { version: "0.2.2" }; },
+      getManifest() { return { version: "0.2.3" }; },
       onInstalled: simpleEvent(),
       onMessage: runtimeEvent,
       async sendMessage(message) { runtimeMessages.push(message); },

--- a/tests/e2e_chromium.py
+++ b/tests/e2e_chromium.py
@@ -419,9 +419,9 @@ def run_live(browser_binary: Path, headed: bool) -> dict:
                     "bindings": {},
                     "selectedScope": {"profileId": profile_a, "sessionId": session_a},
                     "upgradeNotice": {
-                        "id": "companion-reinstall-0.2.2",
-                        "previousVersion": "0.2.1",
-                        "extensionVersion": "0.2.2",
+                        "id": "companion-reinstall-0.2.3",
+                        "previousVersion": "0.2.2",
+                        "extensionVersion": "0.2.3",
                     },
                 }
                 cdp.evaluate(
@@ -468,7 +468,7 @@ def run_live(browser_binary: Path, headed: bool) -> dict:
             frame_url = panel_state.get("frame", "")
             if "resume=session-a" not in frame_url or "profile=profile-a" not in frame_url:
                 raise AssertionError(f"real side panel did not resume the selected session: {frame_url}")
-            if panel_state.get("noticeHidden") or "0.2.2" not in panel_state.get("noticeText", ""):
+            if panel_state.get("noticeHidden") or "0.2.3" not in panel_state.get("noticeText", ""):
                 raise AssertionError(f"companion update notice was not visible: {panel_state}")
             if not panel_state.get("setupHidden"):
                 raise AssertionError(f"first-run setup stayed visible after pairing configuration: {panel_state}")
@@ -882,7 +882,7 @@ def run_live(browser_binary: Path, headed: bool) -> dict:
                 panel_cdp.close()
             if (not first_run or "What is the companion?" not in first_run.get("text", "") or
                     "Do not reinstall" not in first_run.get("text", "") or
-                    not first_run.get("href", "").endswith("hermes-connector-0.2.2-companion.zip") or
+                    not first_run.get("href", "").endswith("hermes-connector-0.2.3-companion.zip") or
                     first_run.get("status") != "companion detected — enter pairing code" or
                     first_run.get("visibleModals") != 1):
                 raise AssertionError(f"first-run companion setup was incomplete: {first_run}")

--- a/tests/e2e_installer_posix.sh
+++ b/tests/e2e_installer_posix.sh
@@ -2,6 +2,8 @@
 set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+EXPECTED_VERSION=$(sed -n 's/^version:[[:space:]]*//p' "$ROOT/hermes-plugin/plugin.yaml")
+test -n "$EXPECTED_VERSION"
 TMP_BASE=${TMPDIR:-/tmp}
 TMP_BASE=${TMP_BASE%/}
 TEST_ROOT=$(mktemp -d "$TMP_BASE/hermes-connector-install-XXXXXX")
@@ -40,6 +42,6 @@ PLUGIN="$TEST_ROOT/plugins/hermes-connector"
 PROFILE_PLUGIN="$TEST_ROOT/profiles/work/plugins/hermes-connector"
 test -f "$PLUGIN/plugin.yaml"
 test -f "$PROFILE_PLUGIN/plugin.yaml"
-grep -q "version: 0.2.2" "$PLUGIN/plugin.yaml"
-grep -q "version: 0.2.2" "$PROFILE_PLUGIN/plugin.yaml"
+grep -Fqx "version: $EXPECTED_VERSION" "$PLUGIN/plugin.yaml"
+grep -Fqx "version: $EXPECTED_VERSION" "$PROFILE_PLUGIN/plugin.yaml"
 printf '%s\n' "POSIX companion install passed: $PLUGIN and $PROFILE_PLUGIN"

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -65,6 +65,32 @@ def metadata_gate() -> None:
     privacy = (ROOT / "PRIVACY.md").read_text(encoding="utf-8")
     if manifest["version"] not in listing:
         raise SystemExit("store gate failed: listing version differs from the manifest")
+    version = manifest["version"]
+    companion_name = f"hermes-connector-{version}-companion.zip"
+    companion_url = (
+        f"https://github.com/CorsenAI/hermes-connector/releases/download/"
+        f"v{version}/{companion_name}"
+    )
+    release_contract = {
+        "extension/src/sidepanel.html": (companion_url, f"Download companion {version}"),
+        "extension/src/sidepanel.js": (f"Download companion {version}",),
+        "PUBLISHING.md": (companion_url,),
+        "store/LISTING.md": (
+            f"dist/hermes-connector-{version}-chrome.zip",
+            companion_url,
+        ),
+        "docs/ACCEPTANCE.md": (f"Store ID serves {version}",),
+        "README.md": (companion_url,),
+        "docs/index.html": (companion_url,),
+        "docs/support/index.html": (companion_url,),
+    }
+    for relative, snippets in release_contract.items():
+        source = (ROOT / relative).read_text(encoding="utf-8")
+        for snippet in snippets:
+            if snippet not in source:
+                raise SystemExit(
+                    f"version gate failed: {relative} is missing current release value {snippet!r}"
+                )
     for disclosure in ("Website content", "Web history", "Authentication information", "Limited Use"):
         if disclosure not in listing and disclosure not in privacy:
             raise SystemExit(f"store gate failed: missing {disclosure} disclosure")
@@ -140,7 +166,7 @@ def leakage_gate() -> None:
 
 def line_ending_gate() -> None:
     tracked = subprocess.check_output(["git", "ls-files", "-z"], cwd=ROOT).decode("utf-8").split("\0")
-    lf_suffixes = {".css", ".html", ".js", ".json", ".md", ".mjs", ".py", ".sh", ".yaml", ".yml"}
+    lf_suffixes = {".css", ".html", ".js", ".json", ".md", ".mjs", ".py", ".sh", ".xml", ".yaml", ".yml"}
     for relative in tracked:
         if not relative:
             continue

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -194,7 +194,7 @@ class CompanionInstallerTests(unittest.TestCase):
 
                 installed_manifest = (target / "plugin.yaml").read_text(encoding="utf-8")
                 installed_broker = (target / "broker.py").read_text(encoding="utf-8")
-                self.assertRegex(installed_manifest, r"(?m)^version:\s*0\.2\.2\s*$")
+                self.assertRegex(installed_manifest, r"(?m)^version:\s*0\.2\.3\s*$")
                 self.assertRegex(installed_broker, r"(?m)^PROTOCOL_VERSION\s*=\s*4\s*$")
                 self.assertRegex(installed_broker, r"(?m)^DEFAULT_PORT\s*=\s*8766\s*$")
 
@@ -238,7 +238,7 @@ class CompanionInstallerTests(unittest.TestCase):
             with self.subTest(contract=label):
                 self.assertIsNotNone(match, f"missing {label} declaration")
 
-        self.assertEqual(extension_manifest["version"], "0.2.2")
+        self.assertEqual(extension_manifest["version"], "0.2.3")
         self.assertEqual(plugin_version.group(1), extension_manifest["version"])
         self.assertEqual(int(broker_protocol.group(1)), 4)
         self.assertEqual(int(extension_protocol_version.group(1)), 4)


### PR DESCRIPTION
## Summary
- bump the Chrome extension and Hermes companion to 0.2.3
- point the packaged extension and reviewer listing at the matching 0.2.3 companion
- exercise the real 0.2.2 -> 0.2.3 companion reinstall notice
- document a safe Store transition: 0.2.2 remains public, 0.2.3 is the candidate, and primary companion CTAs stay version-neutral
- strengthen the release gate against stale versioned links and normalize XML line endings

## Validation
- Windows fast gate: 64 Python tests (58 passed, 6 platform/privilege skips) and 19 JavaScript tests
- Windows PowerShell and normal-user .cmd installers
- POSIX installer under WSL
- real Chrome single-browser and two-browser acceptance
- exact packaged-pair single-browser and two-browser acceptance
- deterministic clean archives

## Artifacts
- chrome ZIP SHA-256: `039d0b569f623a70e8c1f180a3372595d7f733d3160bc195dc1c52864edfc3e7`
- companion ZIP SHA-256: `32fbae02a31874af223cdd06bcce7e02443fa366a0327cc06419aec6db9f55f6`

Closes the distribution follow-up for #5.